### PR TITLE
feat: add Vim mode support for the file editor with toggle functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,38 @@ UTF-8 bytes. Caret/selection painted in `prepaint`; layout cached in `paint` for
 vertical movement. Used for BOTH the file editor and the commit box (lang=PlainText).
 Remaining: undo/redo, soft-wrap, caret-follow scrolling, rope buffer for huge files.
 
+## Vim mode (src/editor/vim.rs)
+Opt-in Vim bindings on the **Browse file editor only** (never the commit box, single-line
+inputs, or diff panes). Toggled via the **Vim mode checkbox in the Settings screen**
+(`render_vim_mode_row` → `Kyde::toggle_vim`, flips + persists immediately on click — no pending
+state like the shell-command row), persisted in `ui.json` (`load_vim`/`save_vim`, key `"vim"`). `Kyde.vim_enabled`
+mirrors the editor flag for the status bar; the file editor is enabled at startup in `app.rs`
+`new` via `CodeEditor::set_vim_enabled`. The status bar shows a per-mode chip
+(`-- NORMAL/INSERT/VISUAL/V-LINE --`, `render_status_bar`), refreshed by a new
+`EditorEvent::VimModeChanged` the Kyde view subscribes to.
+- **State**: `CodeEditor.vim: vim::Vim` { `enabled`, `mode` (`VimMode` Normal/Insert/Visual/
+  VisualLine), `pending` (multi-key buffer), `register` + `register_linewise` (unnamed yank/
+  delete register), `visual_anchor`/`visual_caret` }. Inert while `!enabled` — a non-vim editor
+  behaves exactly as before.
+- **Keystroke gate**: `vim_key` is an `on_key_down` listener (registered BEFORE
+  `on_key_down_nav`, multi-line only). In Normal/Visual mode it interprets the key as a command
+  and calls `cx.stop_propagation()`, which makes gpui skip the OS input handler
+  (`window.rs`: `if !result.propagate { return }` before the IME path) so the key isn't typed.
+  Belt-and-suspenders: every mutation entry point (`replace_text_in_range`,
+  `replace_and_mark_text_in_range`, backspace/delete/enter/indent/outdent/delete_to_home/cut/
+  paste) early-returns when `vim_blocks_edit()` (enabled && mode != Insert).
+- **Parser** (pure, unit-tested — no gpui): `parse(buf) -> Parsed{Cmd|Pending|Invalid}` over the
+  pending buffer, with leading `[1-9][0-9]*` counts (`split_count`; a leading `0` is the
+  line-start motion). `Motion`/`Cmd`/`Op`/`InsertAt` enums; word-class helpers
+  (`word_forward`/`word_backward`/`word_end`, `class` with `big` for WORD). `CodeEditor` methods
+  below execute commands via `vim_replace` (bypasses the edit guard).
+- **Supported**: motions h/j/k/l/w/W/b/B/e/E/0/^/$/gg/G/{/} (+counts, arrows/Home/End/Enter/
+  Backspace); insert i/a/I/A/o/O; edits x/X/D/C/s/S/r<char>/J; operators d/c/y × {motion, doubled
+  dd/cc/yy} (cw acts like ce); p/P (charwise + linewise); u + Ctrl-r; Visual v / Visual-Line V
+  with motions + d/y/c/x; Esc → Normal (and cancels a pending command). Normal-mode caret rests
+  ON a char (`clamp_normal_caret`); a translucent **block cursor** is painted in `element.rs`
+  when `vim_block_cursor()`.
+
 ## Keymap / finder / onboarding (src/keymap.rs + main.rs)
 - `keymap.rs`: `Keymap { preset, overrides }` serialized to `~/.config/kyde/keymap.json`
   (XDG_CONFIG_HOME respected). `ACTIONS` table holds each configurable action's name +

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,7 +87,13 @@ impl Kyde {
             e
         });
         // No placeholder: an empty open file should read as empty, not show prompt text.
-        let file_editor = cx.new(|cx| CodeEditor::new(cx, String::new(), Lang::PlainText, ""));
+        // Vim bindings (persisted in ui.json) apply to this editor only — never the commit
+        // box, single-line inputs, or diff panes.
+        let file_editor = cx.new(|cx| {
+            let mut e = CodeEditor::new(cx, String::new(), Lang::PlainText, "");
+            e.set_vim_enabled(load_vim(), cx);
+            e
+        });
         // Diff panes: left read-only (base), right editable (working copy, live-saves). The
         // base pane renders its line numbers on the RIGHT, toward the center gutter, so the
         // two panes' numbers meet in the middle (IntelliJ/GitHub side-by-side style).
@@ -121,8 +127,11 @@ impl Kyde {
         // `dirty` so loading a file (set_content emits Changed with dirty=false) doesn't
         // rewrite it; real edits/undo set dirty=true and flush here.
         cx.subscribe(&file_editor, |this, _e, ev, cx| {
-            if matches!(ev, EditorEvent::Changed) && this.file_editor.read(cx).dirty {
-                this.autosave(cx);
+            match ev {
+                EditorEvent::Changed if this.file_editor.read(cx).dirty => this.autosave(cx),
+                // Vim mode switch → repaint the status-bar mode indicator.
+                EditorEvent::VimModeChanged => cx.notify(),
+                _ => {}
             }
         })
         .detach();
@@ -285,6 +294,7 @@ impl Kyde {
             find_idx: 0,
             diff_edit_gen: 0,
             finder_gen: 0,
+            vim_enabled: load_vim(),
             show_fps: load_show_fps(),
             fps_value: 0.0,
             fps_shown: 0.0,
@@ -2524,6 +2534,17 @@ impl Kyde {
         self.show_fps = !self.show_fps;
         self.fps_last = None;
         save_show_fps(self.show_fps); // remember across launches
+        cx.notify();
+    }
+
+    /// Toggle Vim bindings on the file editor + persist. Driven by the Vim-mode
+    /// checkbox in the Settings screen (`render_vim_mode_row`).
+    pub(crate) fn toggle_vim(&mut self, cx: &mut Context<Self>) {
+        let on = !self.vim_enabled;
+        self.vim_enabled = on;
+        save_vim(on);
+        self.file_editor
+            .update(cx, |e, cx| e.set_vim_enabled(on, cx));
         cx.notify();
     }
     /// Escape: close whatever overlay is open (most-transient first); if none, cancel the

--- a/src/editor/element.rs
+++ b/src/editor/element.rs
@@ -358,20 +358,44 @@ impl Element for EditorElement {
         }
         // The blinking caret itself only shows when focused — including on an empty field
         // (placeholder showing), so a focused input reads as focused.
-        if editor.focus_handle.is_focused(window) && sel.is_empty() && editor.blink_on {
+        // Vim Normal mode draws a solid (non-blinking) block over the char under the cursor;
+        // the insert/normal caret is the usual thin blinking bar.
+        let vim_block = editor.vim_block_cursor();
+        if editor.focus_handle.is_focused(window)
+            && sel.is_empty()
+            && (vim_block || editor.blink_on)
+        {
             let (li, start) = locate_in(&line_starts, &editor.content, cursor);
             if let Some(line) = lines.get(&li) {
                 let x = line.x_for_index(cursor - start);
                 let y = bounds.top() + line_height * li as f32;
-                // 1px-wide (thinner) caret, nudged 1px left so it has a touch more margin on
-                // its right edge before the next glyph.
-                caret = Some(fill(
-                    Bounds::new(
-                        point(text_x + x - px(1.0), y),
-                        gpui::size(px(1.0), line_height),
-                    ),
-                    theme::get().caret,
-                ));
+                if vim_block {
+                    // Width = the glyph under the cursor; at line end fall back to one cell.
+                    let end = editor.vim_cursor_char_end(cursor);
+                    let w = if end > cursor {
+                        (line.x_for_index(end - start) - x).max(px(2.0))
+                    } else {
+                        px(theme::get().editor_font_size * 0.6)
+                    };
+                    // Translucent so the underlying character (painted before the caret quad)
+                    // stays readable through the block.
+                    let mut col = theme::get().caret;
+                    col.a = 0.42;
+                    caret = Some(fill(
+                        Bounds::new(point(text_x + x, y), gpui::size(w, line_height)),
+                        col,
+                    ));
+                } else {
+                    // 1px-wide (thinner) caret, nudged 1px left so it has a touch more margin
+                    // on its right edge before the next glyph.
+                    caret = Some(fill(
+                        Bounds::new(
+                            point(text_x + x - px(1.0), y),
+                            gpui::size(px(1.0), line_height),
+                        ),
+                        theme::get().caret,
+                    ));
+                }
             }
         } else if !sel.is_empty() {
             // paint a rect per covered display row

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -25,6 +25,9 @@ use unicode_segmentation::UnicodeSegmentation;
 mod element;
 use element::EditorElement;
 
+pub mod vim;
+use vim::Vim;
+
 /// Width of the fold gutter (chevron column) drawn left of the text, when the
 /// buffer has any foldable regions. Zero otherwise (single-line inputs, plain
 /// text with no grammar) so those editors look exactly as before.
@@ -119,6 +122,8 @@ pub fn bind_keys(cx: &mut App) {
 /// Emitted whenever the text changes (used by the file finder to re-query live).
 pub enum EditorEvent {
     Changed,
+    /// The Vim mode changed (Normal/Insert/Visual) — lets the parent repaint the status bar.
+    VimModeChanged,
 }
 
 /// A point-in-time editor state for the undo/redo stacks.
@@ -258,6 +263,9 @@ pub struct CodeEditor {
     /// so this pane lines up row-for-row with the other side. `filler_end` = trailing blanks.
     pub filler: std::collections::HashMap<usize, usize>,
     pub filler_end: usize,
+
+    /// Vim editing mode (inert unless `vim.enabled`; only the Browse file editor enables it).
+    vim: Vim,
 }
 
 impl CodeEditor {
@@ -334,6 +342,7 @@ impl CodeEditor {
             word_bg_color: gpui::rgba(0x00000000),
             filler: std::collections::HashMap::new(),
             filler_end: 0,
+            vim: Vim::default(),
         }
     }
 
@@ -362,6 +371,7 @@ impl CodeEditor {
         self.redo_stack.clear();
         self.last_edit = EditKind::Other;
         self.folded.clear();
+        self.vim_reset();
         self.recompute_folds(cx);
         cx.notify();
         cx.emit(EditorEvent::Changed);
@@ -771,23 +781,35 @@ impl CodeEditor {
         }
     }
     fn backspace(&mut self, _: &Backspace, window: &mut Window, cx: &mut Context<Self>) {
+        if self.vim_blocks_edit() {
+            return; // handled as a Vim command in `vim_key`
+        }
         if self.selected_range.is_empty() {
             self.select_to(self.prev_boundary(self.cursor()), cx);
         }
         self.replace_text_in_range(None, "", window, cx);
     }
     fn delete(&mut self, _: &Delete, window: &mut Window, cx: &mut Context<Self>) {
+        if self.vim_blocks_edit() {
+            return;
+        }
         if self.selected_range.is_empty() {
             self.select_to(self.next_boundary(self.cursor()), cx);
         }
         self.replace_text_in_range(None, "", window, cx);
     }
     fn enter(&mut self, _: &Enter, window: &mut Window, cx: &mut Context<Self>) {
+        if self.vim_blocks_edit() {
+            return;
+        }
         self.replace_text_in_range(None, "\n", window, cx);
     }
     /// cmd-backspace: delete from the caret back to the start of the current line
     /// (or just delete the selection if there is one).
     fn delete_to_home(&mut self, _: &DeleteToHome, window: &mut Window, cx: &mut Context<Self>) {
+        if self.vim_blocks_edit() {
+            return;
+        }
         if self.selected_range.is_empty() {
             let caret = self.cursor();
             let line_start = self.content[..caret]
@@ -800,7 +822,7 @@ impl CodeEditor {
     }
 
     fn indent(&mut self, _: &Indent, _: &mut Window, cx: &mut Context<Self>) {
-        if self.read_only {
+        if self.read_only || self.vim_blocks_edit() {
             return;
         }
         if self.selected_range.start == self.selected_range.end {
@@ -815,7 +837,7 @@ impl CodeEditor {
         }
     }
     fn outdent(&mut self, _: &Outdent, _: &mut Window, cx: &mut Context<Self>) {
-        if !self.read_only {
+        if !self.read_only && !self.vim_blocks_edit() {
             self.shift_lines(false, cx);
         }
     }
@@ -874,6 +896,9 @@ impl CodeEditor {
         }
     }
     fn cut(&mut self, _: &Cut, window: &mut Window, cx: &mut Context<Self>) {
+        if self.vim_blocks_edit() {
+            return;
+        }
         if !self.selected_range.is_empty() {
             cx.write_to_clipboard(gpui::ClipboardItem::new_string(
                 self.content[self.selected_range.clone()].to_string(),
@@ -882,6 +907,9 @@ impl CodeEditor {
         }
     }
     fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
+        if self.vim_blocks_edit() {
+            return;
+        }
         if let Some(text) = cx.read_from_clipboard().and_then(|i| i.text()) {
             self.replace_text_in_range(None, &text, window, cx);
         }
@@ -1299,7 +1327,7 @@ impl EntityInputHandler for CodeEditor {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.read_only {
+        if self.read_only || self.vim_blocks_edit() {
             return;
         }
         let range = range_utf16
@@ -1335,7 +1363,7 @@ impl EntityInputHandler for CodeEditor {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.read_only {
+        if self.read_only || self.vim_blocks_edit() {
             return;
         }
         let range = range_utf16
@@ -1459,6 +1487,9 @@ impl Render for CodeEditor {
                     .on_action(cx.listener(Self::enter))
                     .on_action(cx.listener(Self::indent))
                     .on_action(cx.listener(Self::outdent))
+                    // Vim normal/visual command handling — must run first so it can
+                    // `stop_propagation` and suppress text insertion. A no-op when Vim is off.
+                    .on_key_down(cx.listener(Self::vim_key))
                     // Held ↑/↓ → accelerating auto-repeat (OS key-repeat wasn't moving).
                     .on_key_down(cx.listener(Self::on_key_down_nav))
                     .on_key_up(cx.listener(Self::on_key_up_nav))

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,13 @@ actions!(
 // Native menu bar actions.
 actions!(
     kyde_menu,
-    [Quit, ToggleFps, ClearData, OpenPlugins, OpenProject]
+    [
+        Quit,
+        ToggleFps,
+        ClearData,
+        OpenPlugins,
+        OpenProject
+    ]
 );
 
 /// The native macOS menu bar: the app menu (Settings/Plugins/Quit) + a File menu with
@@ -585,6 +591,9 @@ struct Kyde {
     /// Bumped on every Find-in-Files keystroke; the debounced background `git grep` only
     /// applies its results when its captured generation still matches (drops stale searches).
     finder_gen: u64,
+    /// Vim bindings on the file editor (toggled from the Kyde menu; persisted in ui.json).
+    /// Mirrors the file editor's own flag so the status bar can read it without a borrow.
+    vim_enabled: bool,
     /// FPS monitor (toggled from the Kyde menu): smoothed frames-per-second + last frame time.
     show_fps: bool,
     fps_value: f32,
@@ -1211,6 +1220,13 @@ fn load_show_fps() -> bool {
 }
 fn save_show_fps(v: bool) {
     save_ui_bool("show_fps", v);
+}
+/// Whether the file editor uses Vim bindings (persisted across launches).
+fn load_vim() -> bool {
+    load_ui_bool("vim", false)
+}
+fn save_vim(v: bool) {
+    save_ui_bool("vim", v);
 }
 
 /// The app's standard checkbox: a small rounded square, filled with `check.svg` when ticked.

--- a/src/render.rs
+++ b/src/render.rs
@@ -4567,6 +4567,7 @@ impl Kyde {
                     .child(preset_card(Preset::VSCode, cx)),
             )
             .child(self.render_shell_command_row(cx))
+            .child(self.render_vim_mode_row(cx))
             // Single primary action, bottom-right: confirm the highlighted choice.
             .child(
                 div().flex().flex_row().justify_end().mt_2().child(
@@ -4694,11 +4695,80 @@ impl Kyde {
         col.into_any_element()
     }
 
+    /// Settings-screen toggle for Vim editing on the Browse file editor. Flips
+    /// immediately (and persists to ui.json) on click — unlike the shell-command
+    /// checkbox, there's no pending state to apply on Continue.
+    fn render_vim_mode_row(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let t = theme::get();
+        let checked = self.vim_enabled;
+
+        let checkbox = div()
+            .size_4()
+            .rounded_sm()
+            .border_1()
+            .border_color(if checked { t.primary } else { t.bg_light })
+            .when(checked, |d| d.bg(t.primary))
+            .flex()
+            .items_center()
+            .justify_center()
+            .when(checked, |d| {
+                d.child(
+                    div()
+                        .text_color(gpui::white())
+                        .text_size(px(11.0))
+                        .child("✓"),
+                )
+            });
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_2()
+            .pt_3()
+            .mt_1()
+            .border_t_1()
+            .border_color(t.divider)
+            .cursor_pointer()
+            .child(checkbox)
+            .child(
+                div()
+                    .text_color(t.secondary_text)
+                    .child("Vim mode — Vim keybindings in the file editor"),
+            )
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _e, _w, cx| this.toggle_vim(cx)),
+            )
+            .into_any_element()
+    }
+
     /// Bottom status bar — currently just the branch switcher, anchored bottom-right.
     fn render_status_bar(&self, ui: &'static str, cx: &mut Context<Self>) -> gpui::AnyElement {
         let t = theme::get();
         // All bottom-bar text is this muted grey; icons keep their own colours.
         let bar_text = gpui::rgb(0x808289);
+
+        // Vim mode chip (only when Vim bindings are on): "NORMAL"/"INSERT"/"VISUAL", tinted
+        // per mode so the current mode reads at a glance.
+        let vim_label = self.file_editor.read(cx).vim_mode_label();
+        let vim_chip = vim_label.map(|label| {
+            let col = match label {
+                "INSERT" => t.status_added,
+                "VISUAL" | "V-LINE" => t.status_modified,
+                _ => t.primary,
+            };
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .flex_none()
+                .px_1p5()
+                .rounded_md()
+                .bg(t.bg_light)
+                .text_color(col)
+                .child(SharedString::from(format!("-- {label} --")))
+        });
         let label = self
             .current_branch
             .clone()
@@ -4907,6 +4977,7 @@ impl Kyde {
                     .items_center()
                     .flex_none()
                     .gap_2()
+                    .when_some(vim_chip, |d, chip| d.child(chip))
                     // Only show Pull when we know we're behind (or one's in flight).
                     .when(self.behind.unwrap_or(0) > 0 || self.pulling, |d| {
                         d.child(pull_btn)


### PR DESCRIPTION
## What & why
Implement a VIM editing mode for file editing.

## How to test
1. Run application
2. Activate VIM mode in settings (check the checkbox)
3. Open any file in the file browser
4. The file opens in "normal" Vi mode, press i to enter into insert mode, or v to enter into visual mode.

## Speed & footprint
Kyde's whole reason to exist is being **genuinely fast** with a small footprint, so every
PR gets the same quick gut-check. Tick what applies:

- [X] No new work added to a **hot path** (per-keystroke highlight, per-frame render,
      per-file-select diff) — or if there is, it's justified and has a `perf_*` guard test.
- [X] No new **always-on dependency** that bloats the binary / resident RAM. If a heavy,
      optional thing was added, it's behind a **Cargo feature** (see README → Trimming the
      build) so builds can drop it.
- [X] Startup still feels instant (the app should open before you finish letting go of the
      mouse).
- [ ] N/A — docs / chore / pure refactor with no runtime impact.

## Checklist
- [X] `cargo build` is clean (no new warnings).
- [x] `cargo test` is green (`cargo test perf` if you touched a hot path).
- [X] No vendor code or assets copied from Zed or any GPL source (patterns only — see
      README → Reference material).
- [X] Updated `README.md` / `CLAUDE.md` if behavior or architecture changed.
