### PR TITLE
feat: show +/− line stats — change-set total on the tree root, per-file in the diff pill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,10 @@ editor/  mdview.rs  terminal.rs  remote_img.rs
 clipboard.rs  scratch.rs  shellcmd.rs
 
 # ── workspace crates (pure Rust, no Kyde; see crates/<name>) ──
-kyde-git      Repo: discover/status/base_content/working_content/stage/unstage/apply_patch/
-              commit + Commit/ChangedFile/FileStatus. Shells out to `git`. (thiserror: GitError)
-kyde-diff     FileDiff::compute() → line Hunks + word ranges; hunk_patch(). (similar)
+kyde-git      Repo: discover/status/numstat/base_content/working_content/stage/unstage/
+              apply_patch/commit + Commit/ChangedFile/FileStatus. Shells out to `git`.
+              (thiserror: GitError)
+kyde-diff     FileDiff::compute() → line Hunks + word ranges; stats(); hunk_patch(). (similar)
 kyde-tree     Tree::build/visible — the file-tree model. (std)
 kyde-markdown Block/Span markdown model for the preview. (pulldown-cmark)
 kyde-update   GitHub release check + self-update download/swap. (thiserror: UpdateError, serde_json)
@@ -91,8 +92,9 @@ kyde-color    tiny RGBA `Color` POD shared by theme/syntax. Zero deps; optional 
               feature → `From<Color>` for gpui `Rgba/Hsla/Fill/Background` (UI layer only).
 kyde-theme    runtime dark palette (theme::get/merge, hex JSON). (kyde-color, serde) — gpui-free
 kyde-ui       reusable app-agnostic UI toolkit: btn_primary/secondary, tab_pill, Badge +
-              file_badge, checkbox, menu_icon, lerp_rgb, scrollbar_thumb, the file-tree
-              row `tree::item<V>` (generic over the view), and `picker` (bounded nav_up/
+              file_badge, checkbox, menu_icon, lerp_rgb, scrollbar_thumb, line_stats
+              (`+a −r` label), the file-tree row `tree::item<V>` (generic over the view,
+              optional trailing element), and `picker` (bounded nav_up/
               nav_down + the selected/hover row pill every list picker uses — finder,
               history, push). Aliased back as `ui` in main.rs. (gpui, kyde-theme)
 kyde-syntax   tree-sitter highlight() + fold_regions(); OWNS every grammar crate behind

--- a/crates/kyde-diff/src/lib.rs
+++ b/crates/kyde-diff/src/lib.rs
@@ -151,6 +151,15 @@ impl FileDiff {
 
         FileDiff { old, new, hunks }
     }
+
+    /// Total `(added, removed)` line counts, summed over the hunks (a modified region
+    /// counts on both sides). Matches `git diff --numstat` for the same pair of texts.
+    #[must_use]
+    pub fn stats(&self) -> (usize, usize) {
+        self.hunks.iter().fold((0, 0), |(add, rem), h| {
+            (add + h.new_range.len(), rem + h.old_range.len())
+        })
+    }
 }
 
 /// `(line_idx, byte_range)` pairs for one diff side's word-level highlights.
@@ -265,6 +274,19 @@ mod tests {
         assert_eq!(deleted.hunks[0].kind, HunkKind::Deleted);
 
         assert!(FileDiff::compute("a\nb\n", "a\nb\n").hunks.is_empty());
+    }
+
+    #[test]
+    fn stats_counts_added_and_removed_lines_across_hunks() {
+        // b→B is +1 −1, the appended d/e is +2 — totals must span hunks.
+        assert_eq!(
+            FileDiff::compute("a\nb\nc\n", "a\nB\nc\nd\ne\n").stats(),
+            (3, 1)
+        );
+        assert_eq!(FileDiff::compute("a\nb\n", "a\n").stats(), (0, 1));
+        assert_eq!(FileDiff::compute("x\n", "x\n").stats(), (0, 0));
+        // A new file is all additions.
+        assert_eq!(FileDiff::compute("", "a\nb\n").stats(), (2, 0));
     }
 
     #[test]

--- a/crates/kyde-git/src/lib.rs
+++ b/crates/kyde-git/src/lib.rs
@@ -224,6 +224,43 @@ impl Repo {
         Ok(files)
     }
 
+    /// Added/removed line counts per changed file — one `git diff --numstat` against HEAD
+    /// (worktree + index, matching the working-vs-HEAD diff the commit view shows), plus a
+    /// line count for each untracked file (all additions). Binary files are omitted: numstat
+    /// reports `-` for them and `+0 −0` would be a lie. An unborn HEAD yields no diff, so a
+    /// brand-new repo just gets the untracked counts.
+    pub fn numstat(&self) -> Result<std::collections::HashMap<PathBuf, (usize, usize)>> {
+        let mut stats = std::collections::HashMap::new();
+        // Each `-z` record is `added TAB removed TAB path NUL` (`--no-renames` keeps the
+        // single-path shape; renames would splice a second path field into the record).
+        let raw = git(
+            &self.root,
+            &["diff", "--numstat", "--no-renames", "-z", "HEAD"],
+        )
+        .unwrap_or_default();
+        for rec in raw.split('\0').filter(|s| !s.is_empty()) {
+            let mut it = rec.splitn(3, '\t');
+            let (Some(add), Some(rem), Some(path)) = (it.next(), it.next(), it.next()) else {
+                continue;
+            };
+            // Binary file → `-\t-` → both parses fail → skipped.
+            if let (Ok(a), Ok(r)) = (add.parse(), rem.parse()) {
+                stats.insert(PathBuf::from(path), (a, r));
+            }
+        }
+        let untracked = git(
+            &self.root,
+            &["ls-files", "--others", "--exclude-standard", "-z"],
+        )?;
+        for path in untracked.split('\0').filter(|s| !s.is_empty()) {
+            // Binary/non-UTF-8 content errors here — omit it, same as tracked binaries.
+            if let Ok(content) = self.working_content(Path::new(path)) {
+                stats.insert(PathBuf::from(path), (content.lines().count(), 0));
+            }
+        }
+        Ok(stats)
+    }
+
     /// HEAD version of a file = the "before" side of the commit diff. We compare the working
     /// tree against HEAD (not the index) so the diff always shows the *full* change that will
     /// be committed — `commit_now` re-stages each checked file's working copy before
@@ -816,6 +853,44 @@ mod tests {
             repo.stage(Path::new("ignored.txt")).is_err(),
             "staging an ignored (existing) file must still surface git's error"
         );
+
+        let _ = fs::remove_dir_all(&work);
+    }
+
+    /// One `numstat` call must size every kind of change in the list: a tracked edit, a
+    /// worktree deletion, and an untracked file (all additions). Binary files can't be
+    /// line-counted, so they're omitted rather than reported as `+0 −0`.
+    #[test]
+    fn numstat_reports_added_and_removed_lines_per_file() {
+        use std::fs;
+        let g = |dir: &Path, args: &[&str]| {
+            git(dir, args).unwrap_or_else(|e| panic!("git {args:?} failed: {e}"))
+        };
+        let work = std::env::temp_dir().join(format!("kyde-numstat-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&work);
+        fs::create_dir_all(&work).unwrap();
+        g(&work, &["init", "-b", "main"]);
+        g(&work, &["config", "user.email", "t@example.com"]);
+        g(&work, &["config", "user.name", "Test"]);
+        g(&work, &["config", "commit.gpgsign", "false"]);
+        fs::write(work.join("kept.txt"), "one\ntwo\nthree\n").unwrap();
+        fs::write(work.join("gone.txt"), "a\nb\n").unwrap();
+        fs::write(work.join("blob.bin"), [0u8, 1, 2]).unwrap();
+        g(&work, &["add", "-A"]);
+        g(&work, &["commit", "-m", "init"]);
+
+        // One line changed + two added; a deletion; an untracked file; a binary edit.
+        fs::write(work.join("kept.txt"), "one\nTWO\nthree\nfour\nfive\n").unwrap();
+        fs::remove_file(work.join("gone.txt")).unwrap();
+        fs::write(work.join("new.txt"), "x\ny\nz\n").unwrap();
+        fs::write(work.join("blob.bin"), [0u8, 9, 9, 9]).unwrap();
+
+        let repo = Repo::discover(&work).unwrap();
+        let stats = repo.numstat().unwrap();
+        assert_eq!(stats.get(Path::new("kept.txt")), Some(&(3, 1)));
+        assert_eq!(stats.get(Path::new("gone.txt")), Some(&(0, 2)));
+        assert_eq!(stats.get(Path::new("new.txt")), Some(&(3, 0)));
+        assert!(!stats.contains_key(Path::new("blob.bin")));
 
         let _ = fs::remove_dir_all(&work);
     }

--- a/crates/kyde-ui/src/lib.rs
+++ b/crates/kyde-ui/src/lib.rs
@@ -14,6 +14,7 @@ mod menu;
 pub mod picker;
 mod scrollbar;
 mod select;
+mod stats;
 mod tab;
 /// Call sites use the explicit `ui::tree::item(…)`.
 pub mod tree;
@@ -26,4 +27,5 @@ pub use footer::*;
 pub use menu::*;
 pub use scrollbar::*;
 pub use select::*;
+pub use stats::*;
 pub use tab::*;

--- a/crates/kyde-ui/src/stats.rs
+++ b/crates/kyde-ui/src/stats.rs
@@ -1,0 +1,32 @@
+//! `+a −r` line-count label (IDE diff-stats style), shared by the changed-files tree
+//! rows and the diff nav.
+use gpui::prelude::*;
+use gpui::{div, px};
+use kyde_theme as theme;
+
+/// Small `+a −r` spans in the theme's added/deleted colors. Zero sides are dropped and
+/// `(0, 0)` renders nothing at all, so untouched rows stay exactly as they were.
+pub fn line_stats(added: usize, removed: usize) -> Option<gpui::AnyElement> {
+    if added == 0 && removed == 0 {
+        return None;
+    }
+    let t = theme::get();
+    let mut row = div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .flex_none()
+        .gap_1()
+        .text_size(px(t.ui_font_size));
+    if added > 0 {
+        row = row.child(div().text_color(t.status_added).child(format!("+{added}")));
+    }
+    if removed > 0 {
+        row = row.child(
+            div()
+                .text_color(t.status_deleted)
+                .child(format!("−{removed}")),
+        );
+    }
+    Some(row.into_any_element())
+}

--- a/crates/kyde-ui/src/tree.rs
+++ b/crates/kyde-ui/src/tree.rs
@@ -22,6 +22,7 @@ pub fn item<V: 'static>(
     name: SharedString,
     name_color: kyde_color::Color,
     checkbox: Option<bool>,
+    trailing: Option<gpui::AnyElement>,
     on_activate: impl Fn(&mut V, &gpui::MouseDownEvent, &mut Window, &mut Context<V>) + 'static,
     on_check: impl Fn(&mut V, &mut Context<V>) + 'static,
     on_context: impl Fn(&mut V, gpui::Point<Pixels>, &mut Context<V>) + 'static,
@@ -104,7 +105,8 @@ pub fn item<V: 'static>(
                 .truncate()
                 .text_color(name_color)
                 .child(name),
-        );
+        )
+        .when_some(trailing, gpui::ParentElement::child);
 
     div()
         .flex()

--- a/src/app.rs
+++ b/src/app.rs
@@ -81,6 +81,8 @@ fn list_dir_files(root: &std::path::Path) -> Vec<PathBuf> {
 struct RepoSnapshot {
     /// Changed files from `git status` (empty when `status_err` is set).
     files: Vec<ChangedFile>,
+    /// Per-file `(added, removed)` line counts for `files` (see [`Repo::numstat`]).
+    stats: std::collections::HashMap<std::path::PathBuf, (usize, usize)>,
     /// `Some(message)` when `git status` failed — surfaced as the op-error banner while
     /// the previous file list is kept (so a transient failure doesn't blank the tree).
     status_err: Option<String>,
@@ -112,6 +114,7 @@ impl RepoSnapshot {
             // git-only state stays empty.
             return Self {
                 files: Vec::new(),
+                stats: std::collections::HashMap::new(),
                 status_err: None,
                 all_files: list_dir_files(root),
                 current_branch: None,
@@ -131,6 +134,7 @@ impl RepoSnapshot {
         };
         Self {
             files,
+            stats: repo.numstat().unwrap_or_default(),
             status_err,
             all_files: repo.list_files().unwrap_or_default(),
             current_branch: repo.current_branch(),
@@ -195,6 +199,7 @@ impl Kyde {
             recents: Recents::load(),
             project_search,
             files: Vec::new(),
+            stats: std::collections::HashMap::new(),
             selected: None,
             commit: CommitView::new(cx),
             diff: DiffPanes::new(cx),
@@ -293,6 +298,7 @@ impl Kyde {
             // Landing view / project closed: no repo to read — clear git-derived state so a
             // stale tree/branch never lingers behind the landing view.
             self.files.clear();
+            self.stats.clear();
             self.sync.push_files.clear();
             self.current_branch = None;
             self.sync.ahead = None;
@@ -348,10 +354,12 @@ impl Kyde {
                 self.op_error = Some(msg);
             } else {
                 self.files = snap.files;
+                self.stats = snap.stats;
                 self.op_error = None;
             }
         } else {
             self.files.clear();
+            self.stats.clear();
             self.sync.push_files.clear();
             self.op_error = None;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1124,6 +1124,9 @@ struct Kyde {
 
     // Commit mode
     files: Vec<ChangedFile>,
+    /// Per-file `(added, removed)` line counts (numstat), refreshed with `files`. Files
+    /// absent here (binaries) just render without the count.
+    stats: std::collections::HashMap<PathBuf, (usize, usize)>,
     selected: Option<usize>,
     /// Commit view (checkbox tree, message editor, chrome) — grouped into one sub-struct
     /// (see `CommitView`).

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -343,6 +343,7 @@ impl Kyde {
                     name,
                     name_color,
                     None,
+                    None,
                     move |this, e, window, cx| {
                         // Folders toggle expansion. Files (VS Code-style): single click opens in
                         // the temporary *preview* tab (reused by the next single-click), double

--- a/src/views/commit.rs
+++ b/src/views/commit.rs
@@ -237,6 +237,17 @@ impl Kyde {
                 };
                 let expanded = self.commit.expanded.contains(&r.path);
                 let is_dir = r.is_dir;
+                // The whole change set's `+a −r` total on the root row only — per-file counts
+                // live in the diff's floating pill, so filenames keep the full row width.
+                let stats = is_root
+                    .then(|| {
+                        let (a, d) = self
+                            .stats
+                            .values()
+                            .fold((0, 0), |(a, d), (fa, fd)| (a + fa, d + fd));
+                        ui::line_stats(a, d)
+                    })
+                    .flatten();
                 let (p_act, p_check, p_ctx) = (r.path.clone(), r.path.clone(), r.path.clone());
                 ui::tree::item(
                     cx,
@@ -249,6 +260,7 @@ impl Kyde {
                     name,
                     name_color,
                     Some(checked),
+                    stats,
                     move |this, _e, _w, cx| {
                         if is_dir {
                             this.toggle_commit_dir(p_act.clone(), cx);

--- a/src/views/diff_view.rs
+++ b/src/views/diff_view.rs
@@ -324,17 +324,26 @@ impl Kyde {
             .into_any_element()
     }
 
-    /// A small floating control at the diff's top-right: the change count + prev/next arrows
-    /// that jump between hunks. Shown whenever the current diff has at least one change.
+    /// A small floating pill at the diff's top-right: the change count + the file's `+a −r`
+    /// line stats, plus prev/next arrows that jump between hunks (only when there are 2+ to
+    /// jump between). Shown whenever the current diff has at least one change.
     fn render_diff_nav(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
         let n = self.diff.current.as_ref().map_or(0, |d| d.hunks.len());
-        // Nothing to navigate with a single (or zero) change — hide the control.
-        if n < 2 {
+        if n == 0 {
             return None;
         }
+        let nav = n >= 2;
         let t = theme::get();
         let ui = theme::font::UI_FAMILY;
-        let label = format!("{n} changes");
+        let label = if n == 1 {
+            "1 change".to_string()
+        } else {
+            format!("{n} changes")
+        };
+        let stats = self.diff.current.as_ref().and_then(|d| {
+            let (a, r) = d.stats();
+            crate::ui::line_stats(a, r)
+        });
         let arrow = |id: &'static str, icon: &'static str, tip: &'static str, next: bool| {
             div()
                 .id(id)
@@ -379,18 +388,21 @@ impl Kyde {
                 .text_size(px(t.ui_font_size))
                 .text_color(t.secondary_text)
                 .child(div().mr_1().child(label))
-                .child(arrow(
-                    "diff-prev",
-                    "icons/arrow-up.svg",
-                    "Previous change",
-                    false,
-                ))
-                .child(arrow(
-                    "diff-next",
-                    "icons/arrow-down.svg",
-                    "Next change",
-                    true,
-                ))
+                .when_some(stats, |d, s| d.child(div().mr_1().child(s)))
+                .when(nav, |d| {
+                    d.child(arrow(
+                        "diff-prev",
+                        "icons/arrow-up.svg",
+                        "Previous change",
+                        false,
+                    ))
+                    .child(arrow(
+                        "diff-next",
+                        "icons/arrow-down.svg",
+                        "Next change",
+                        true,
+                    ))
+                })
                 .into_any_element(),
         )
     }

--- a/src/views/history.rs
+++ b/src/views/history.rs
@@ -367,6 +367,7 @@ impl Kyde {
                     name,
                     name_color,
                     None,
+                    None,
                     move |this, _e, _w, cx| {
                         if is_dir {
                             if !this.history.files_expanded.remove(&p_act) {

--- a/src/views/rollback.rs
+++ b/src/views/rollback.rs
@@ -64,6 +64,7 @@ impl Kyde {
                     name,
                     name_color,
                     Some(checked),
+                    None,
                     // Click toggles the row's checkbox (folders expand); the diff is reached
                     // by right-click → View Diff, not a plain click.
                     move |this, _e, _w, cx| {


### PR DESCRIPTION
## What & why

kyde showed *which* files changed but never *how much* — no `+/−` line counts anywhere. Size is the first thing you triage by when reviewing, especially agent-written diffs. This adds them in two places, keeping the chrome minimal:

- **Files-tree root row**: the whole change set's total (`+670` style), so one glance sizes the commit.
- **Diff floating pill** (top-right): now shows for *any* changed file as `n changes · +a −r` — previously it only appeared with 2+ hunks; the prev/next arrows still only render when there's something to jump between.

Per-file counts deliberately do **not** sit on the tree rows: in a narrow panel they fight the filename for width.

![diff stats: +670 total on the root row, "1 change +537" in the diff pill](https://raw.githubusercontent.com/Zaimwa9/kyde/assets/docs/diff-stats.png)

Under the hood:
- `kyde-diff`: `FileDiff::stats()` — `(added, removed)` summed over the existing hunks, so the pill costs no extra git call.
- `kyde-git`: `Repo::numstat()` — one `git diff --numstat --no-renames -z HEAD` plus a line count per untracked file; binary files are omitted rather than shown as `+0 −0`. Handles unborn HEAD.
- `kyde-ui`: `line_stats()` label + an optional trailing element on `tree::item` (other trees pass `None`, unaffected).
- Stats are read in the background `RepoSnapshot` refresh alongside `git status` — nothing new on the render path.

Closes #35

## How to test

1. Point kyde at a repo with edits, an untracked file, and ideally a binary change.
2. Commit view: the root row of the changed-files tree shows the total `+a −r`; file rows are unchanged.
3. Select any changed file: the top-right pill reads `n changes · +a −r` (arrows only with 2+ changes). Binary files show no counts.

## Speed & footprint

- [x] No new work added to a **hot path** — numstat runs once per background refresh (same cadence as `git status`), and the pill's stats are a fold over already-computed hunks.
- [x] No new **always-on dependency** — zero new crates.
- [x] Startup still feels instant.

## Checklist

- [x] `cargo build` is clean (no new warnings).
- [x] `cargo test` is green (110 tests across the workspace, incl. two new TDD'd ones: `numstat_reports_added_and_removed_lines_per_file`, `stats_counts_added_and_removed_lines_across_hunks`).
- [x] No vendor code or assets copied from Zed or any GPL source.
- [x] Updated `CLAUDE.md` (crate map: `numstat`, `stats()`, `line_stats`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
