### PR TITLE
fix: keep history/push diff panes open across window refocus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,14 +2919,14 @@ dependencies = [
 
 [[package]]
 name = "kyde-color"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "gpui",
 ]
 
 [[package]]
 name = "kyde-config"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2934,28 +2934,28 @@ dependencies = [
 
 [[package]]
 name = "kyde-diff"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "kyde-git"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kyde-markdown"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "pulldown-cmark",
 ]
 
 [[package]]
 name = "kyde-syntax"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "codebook-tree-sitter-latex",
  "kyde-color",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "kyde-theme"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "kyde-color",
  "serde",
@@ -2988,11 +2988,11 @@ dependencies = [
 
 [[package]]
 name = "kyde-tree"
-version = "2.0.1"
+version = "2.1.0"
 
 [[package]]
 name = "kyde-ui"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "gpui",
  "kyde-color",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "kyde-update"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "serde_json",
  "thiserror 2.0.18",

--- a/src/app.rs
+++ b/src/app.rs
@@ -373,14 +373,27 @@ impl Kyde {
             self.op_error = None;
         }
         self.rebuild_commit_view(false);
-        match self.selected {
-            Some(i) if i < self.files.len() => self.select(i),
-            _ if !self.files.is_empty() => self.select(0),
-            _ => {
+        // Re-selecting keeps the COMMIT view's working diff in sync — but the panes are
+        // shared with History/Push (committed content). Leave those alone, or a clean-tree
+        // refresh blanks an open history diff to "Select a file" on window refocus (#39).
+        // History's "Local" compare is editable, hence the mode check on top of `readonly`.
+        let panes_foreign =
+            self.diff.readonly || (self.mode == Mode::History && !self.diff_view_open);
+        if panes_foreign {
+            // Just keep the commit-view selection index in range.
+            if self.selected.is_some_and(|i| i >= self.files.len()) {
                 self.selected = None;
-                self.diff.current = None;
-                self.diff.old_spans.clear();
-                self.diff.new_spans.clear();
+            }
+        } else {
+            match self.selected {
+                Some(i) if i < self.files.len() => self.select(i),
+                _ if !self.files.is_empty() => self.select(0),
+                _ => {
+                    self.selected = None;
+                    self.diff.current = None;
+                    self.diff.old_spans.clear();
+                    self.diff.new_spans.clear();
+                }
             }
         }
         // The fuzzy finder matches against `all_files` — if it's open while this snapshot
@@ -430,7 +443,12 @@ impl Kyde {
         // refocus the panes must pick up external edits like the Browse editor does: reload
         // them under the same never-clobber rules (no unsaved pane edits, bytes actually
         // changed on disk).
-        if self.mode == Mode::Commit && !self.diff.right.read(cx).dirty {
+        // Commit TAB only — on the Push tab the panes hold a committed diff, and reloading
+        // would swap in an unrelated working-tree file.
+        if self.mode == Mode::Commit
+            && self.git_tab == GitTab::Commit
+            && !self.diff.right.read(cx).dirty
+        {
             if let (Some(i), Some(repo)) = (self.selected, self.repo()) {
                 let changed = self
                     .files
@@ -439,6 +457,27 @@ impl Kyde {
                     .is_some_and(|c| self.diff.right.read(cx).text() != c);
                 if changed {
                     self.select_with(i, Some(cx));
+                }
+            }
+        }
+        // History's working-tree compares ("Local"/"Before → Local") show the working copy
+        // in the right pane too — reload it under the same never-clobber rules.
+        if self.mode == Mode::History
+            && matches!(
+                self.history.compare,
+                CompareMode::Local | CompareMode::BeforeLocal
+            )
+            && !self.diff.right.read(cx).dirty
+        {
+            if let (Some(i), Some(repo)) = (self.history.file_selected, self.repo()) {
+                let changed = self
+                    .history
+                    .files
+                    .get(i)
+                    .and_then(|f| repo.working_content(&f.path).ok())
+                    .is_some_and(|c| self.diff.right.read(cx).text() != c);
+                if changed {
+                    self.select_history_file(i, cx);
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2354,6 +2354,18 @@ mod gpui_smoke_tests {
     use super::*;
     use gpui::TestAppContext;
 
+    /// Run a git command in `dir`, scrubbing the repo-pointing env (see `boot`).
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .unwrap();
+    }
+
     /// Build a `Kyde` window against a throwaway git repo, return its handle + a visual cx.
     fn boot(cx: &mut TestAppContext) -> (gpui::WindowHandle<Kyde>, std::path::PathBuf) {
         // A real temp git repo with one change, so the commit/diff/rollback screens populate.
@@ -2695,6 +2707,128 @@ mod gpui_smoke_tests {
                     "const a = 7; // external\n",
                     "refocus must reload the commit view's working pane"
                 );
+            })
+            .unwrap();
+    }
+
+    /// Refocus with a clean tree while a history diff is open (#39): the empty-status
+    /// refresh must not clear the shared diff panes back to "Select a file".
+    #[gpui::test]
+    fn reload_external_keeps_history_diff_open(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        // Clean tree + 2 commits.
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-qm", "second"]);
+        handle
+            .update(cx, |k, _w, cx| {
+                k.history.compare = CompareMode::Before;
+                k.enter_history(cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, _cx| {
+                assert!(k.diff.current.is_some(), "sanity: history diff loaded");
+                assert_eq!(k.history.file_selected, Some(0));
+            })
+            .unwrap();
+        // Refocus = the activation observer's callback.
+        handle
+            .update(cx, |k, _w, cx| k.reload_external(cx))
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, _cx| {
+                assert!(
+                    k.diff.current.is_some(),
+                    "refocus must not blank the open history diff"
+                );
+                assert!(k.diff.path.is_some());
+                assert_eq!(k.history.file_selected, Some(0));
+            })
+            .unwrap();
+    }
+
+    /// Refocus with a dirty tree while a history diff is open: the refresh must not
+    /// overwrite the committed diff model with the working-tree diff.
+    #[gpui::test]
+    fn reload_external_keeps_history_diff_model(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-qm", "second"]);
+        std::fs::write(dir.join("app.tsx"), "const a = 3;\n").unwrap(); // dirty again
+        handle
+            .update(cx, |k, _w, cx| {
+                k.history.compare = CompareMode::Before;
+                k.enter_history(cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        let new_side = |k: &Kyde| {
+            k.diff
+                .current
+                .as_ref()
+                .expect("history diff loaded")
+                .new
+                .join("\n")
+        };
+        handle
+            .update(cx, |k, _w, _cx| {
+                // Newest commit vs parent: the new side is the committed "a = 2".
+                assert!(new_side(k).contains("const a = 2;"));
+            })
+            .unwrap();
+        handle
+            .update(cx, |k, _w, cx| k.reload_external(cx))
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, _cx| {
+                assert!(
+                    new_side(k).contains("const a = 2;"),
+                    "refocus overwrote the history diff with the working-tree diff: {:?}",
+                    new_side(k)
+                );
+            })
+            .unwrap();
+    }
+
+    /// Refocus in History "Local" compare: the right pane shows the working copy, so
+    /// external edits must reload it (same never-clobber rules as the Commit pane).
+    #[gpui::test]
+    fn reload_external_refreshes_history_local_pane(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-qm", "second"]);
+        std::fs::write(dir.join("app.tsx"), "const a = 3;\n").unwrap(); // dirty again
+        handle
+            .update(cx, |k, _w, cx| {
+                k.history.compare = CompareMode::Local;
+                k.enter_history(cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, cx| {
+                assert_eq!(k.history.file_selected, Some(0), "sanity: file selected");
+                assert_eq!(k.diff.right.read(cx).text(), "const a = 3;\n");
+            })
+            .unwrap();
+        // External tool rewrites the file while Kyde is in the background.
+        std::fs::write(dir.join("app.tsx"), "const a = 4;\n").unwrap();
+        handle
+            .update(cx, |k, _w, cx| k.reload_external(cx))
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, cx| {
+                assert_eq!(
+                    k.diff.right.read(cx).text(),
+                    "const a = 4;\n",
+                    "refocus must reload the history Local-compare working pane"
+                );
+                assert!(k.diff.current.is_some(), "the diff must stay open");
+                assert_eq!(k.history.file_selected, Some(0));
             })
             .unwrap();
     }


### PR DESCRIPTION
## What & why

Closes #39.

Clicking back into kyde re-activates the window, which runs the refocus reload (`reload_external` → async `refresh` → `apply_snapshot`). That path unconditionally re-drove the **Commit view's** file selection into the diff panes — but the panes are shared with the History and Push views:

- With a **clean working tree** (the normal state while reviewing a history/push diff), the empty `git status` cleared the diff model, blanking the open diff to "Select a file" on the first click back into the window — the bug in the issue.
- With a **dirty tree**, it silently recomputed the diff model from an unrelated working-tree file, mis-coloring the open committed diff.

The fix keys on what the panes contain instead of stomping them unconditionally:

- `apply_snapshot` skips the commit-view re-select when History/Push own the panes (`diff.readonly` covers the committed loads; a mode check covers History's editable working-tree compares).
- `reload_external`'s pane reload is gated to the Commit **tab** (on the Push tab it would swap in the wrong file), and now also reloads a History Local-compare pane under the same never-clobber rules (no unsaved pane edits, bytes actually changed), so external edits show up there instead of going stale.

The second commit is a lockfile sync: the 2.1.0 release bumped `[workspace.package].version` but `Cargo.lock` still records the internal crates at 2.0.1, so any build rewrites it and `cargo build --locked` fails. Happy to drop it if you'd rather handle that separately.

## How to test

Repro from the issue (before the fix): open any repo with a clean working tree → History view → select a commit + file so the side-by-side diff shows → switch to another app → click back into kyde → the diff pane resets to "Select a file". Same with a Push-tab diff. After the fix the diff stays put.

Regression tests (gpui smoke tests, all red before the fix / green after):
- `reload_external_keeps_history_diff_open` — clean tree, refocus must not blank the pane
- `reload_external_keeps_history_diff_model` — dirty tree, refocus must not overwrite the committed diff with the working-tree diff
- `reload_external_refreshes_history_local_pane` — Local compare, external edits must reload the working pane

## Speed & footprint

- [x] No new work added to a **hot path** — the change only gates existing refresh work behind cheap field checks.
- [x] No new **always-on dependency**.
- [x] Startup still feels instant.

## Checklist
- [x] `cargo build` is clean (no new warnings).
- [x] `cargo test` is green (`cargo clippy --workspace --all-targets --all-features -- -D warnings` + `cargo test --workspace` both pass).
- [x] No vendor code or assets copied from Zed or any GPL source.
- [ ] Updated `README.md` / `CLAUDE.md` — no behavior/architecture change beyond the bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)