### PR TITLE
feat: error highlighting — parse-error squiggles, on by default per pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,13 +478,14 @@ Shell (bash), CSS, SCSS (reuses CSS grammar), `.env`, `.gitignore`. `.env`/`.git
 use small builtin line highlighters (no grammar). tree-sitter core bumped to **0.25**
 because tree-sitter-md 0.5 emits grammar ABI 15 (0.24's highlighter caps at ABI 14).
 
-### Error highlighting (per-pack opt-in — issue #47)
-Wavy red squiggles under parse errors (tree-sitter `ERROR` + `MISSING` nodes), OFF by
-default and opted in **per pack**: an "Error highlighting" checkbox on each installed
-pack's row in the Language Plugins window (`toggle_pack_errors`; hidden for "font" —
-not a language). A second gate on top of `installed`, persisted as `errors_enabled` in
-plugins.json (`Plugins::errors_on/set_errors`; uninstall drops the opt-in, reinstall
-does NOT resurrect it). Pipeline: `kyde_syntax::error_ranges(source, lang)` (pure —
+### Error highlighting (on by default per pack — issue #47)
+Wavy red squiggles under parse errors (tree-sitter `ERROR` + `MISSING` nodes), **ON by
+default for every installed pack**, with a per-pack opt-OUT: the "Error highlighting"
+checkbox on each installed pack's row in the Language Plugins window
+(`toggle_pack_errors`; hidden for "font" — not a language). Persisted as
+`errors_disabled` in plugins.json (`Plugins::errors_on/set_errors`; empty set — and any
+pre-existing plugins.json — means all on; uninstall drops the opt-out, so reinstall
+returns to default-on). Pipeline: `kyde_syntax::error_ranges(source, lang)` (pure —
 parses, prunes clean subtrees via `node.has_error()`, merges overlaps, widens
 zero-width MISSING to one char; perf guard `perf_error_ranges_large_files_stay_fast`)
 → cached on `CodeEditor.error_ranges`, recomputed with `spans` in `recompute_folds`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,6 +478,26 @@ Shell (bash), CSS, SCSS (reuses CSS grammar), `.env`, `.gitignore`. `.env`/`.git
 use small builtin line highlighters (no grammar). tree-sitter core bumped to **0.25**
 because tree-sitter-md 0.5 emits grammar ABI 15 (0.24's highlighter caps at ABI 14).
 
+### Error highlighting (per-pack opt-in — issue #47)
+Wavy red squiggles under parse errors (tree-sitter `ERROR` + `MISSING` nodes), OFF by
+default and opted in **per pack**: an "Error highlighting" checkbox on each installed
+pack's row in the Language Plugins window (`toggle_pack_errors`; hidden for "font" —
+not a language). A second gate on top of `installed`, persisted as `errors_enabled` in
+plugins.json (`Plugins::errors_on/set_errors`; uninstall drops the opt-in, reinstall
+does NOT resurrect it). Pipeline: `kyde_syntax::error_ranges(source, lang)` (pure —
+parses, prunes clean subtrees via `node.has_error()`, merges overlaps, widens
+zero-width MISSING to one char; perf guard `perf_error_ranges_large_files_stay_fast`)
+→ cached on `CodeEditor.error_ranges`, recomputed with `spans` in `recompute_folds`
+only when `errors_on` (`set_error_highlight`, set by the app from
+`Kyde::errors_enabled_for(lang)` on open/install/toggle — flag BEFORE
+`set_content`/`set_lang` so one recompute does the right thing) → element prepaint
+splits each visible row's `TextRun`s at error boundaries (`apply_error_squiggles`,
+pure + unit-tested) and sets `underline: wavy` in `theme.syn_error` (new palette key,
+CVD variants ride the conflict accent) — the squiggle paints inside the normal
+`ShapedLine` pass, so virtualization is free (off-screen rows never split). Squiggles
+appear wherever the editor's flag is on (Browse; diff/merge panes never set it).
+Debug shot: `KYDE_SHOT=error-highlight` + `KYDE_SHOT_FILE=<invalid .json>`.
+
 ### Two independent layers — Cargo features (build) vs install list (runtime)
 The plugin system is **two separate gates**, do not conflate them:
 - **Cargo features** (`Cargo.toml [features]`, one per pack: `rust`, `typescript`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,14 +2919,14 @@ dependencies = [
 
 [[package]]
 name = "kyde-color"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "gpui",
 ]
 
 [[package]]
 name = "kyde-config"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2934,28 +2934,28 @@ dependencies = [
 
 [[package]]
 name = "kyde-diff"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "kyde-git"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kyde-markdown"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "pulldown-cmark",
 ]
 
 [[package]]
 name = "kyde-syntax"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "codebook-tree-sitter-latex",
  "kyde-color",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "kyde-theme"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "kyde-color",
  "serde",
@@ -2988,11 +2988,11 @@ dependencies = [
 
 [[package]]
 name = "kyde-tree"
-version = "2.1.0"
+version = "2.2.0"
 
 [[package]]
 name = "kyde-ui"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "gpui",
  "kyde-color",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "kyde-update"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/kyde-config/src/plugins.rs
+++ b/crates/kyde-config/src/plugins.rs
@@ -14,10 +14,12 @@ pub struct Plugins {
     /// Set of installed pack ids (see `highlight::PACKS`).
     #[serde(default)]
     installed: BTreeSet<String>,
-    /// Pack ids with error highlighting opted in (a second gate on top of
-    /// `installed`: the pack's parse already runs, this adds the error walk).
+    /// Pack ids with error highlighting opted OUT. Error highlighting is ON by
+    /// default for every installed pack (the pack's parse already runs; the
+    /// error walk is the cheap part) — this records the per-pack "no thanks",
+    /// so an empty set (and any pre-existing plugins.json) means all on.
     #[serde(default)]
-    errors_enabled: BTreeSet<String>,
+    errors_disabled: BTreeSet<String>,
 }
 
 impl Plugins {
@@ -33,24 +35,26 @@ impl Plugins {
 
     /// Remove a pack from the installed set (its grammar is still compiled in, but the
     /// editor falls back to `PlainText` for that language until re-installed).
-    /// Also drops the pack's error-highlighting opt-in.
+    /// Also drops the pack's error-highlighting opt-out (reinstall = fresh defaults).
     pub fn uninstall(&mut self, pack_id: &str) {
         self.installed.remove(pack_id);
-        self.errors_enabled.remove(pack_id);
+        self.errors_disabled.remove(pack_id);
     }
 
-    /// Whether error highlighting is opted in for `pack_id`. Only meaningful when
-    /// the pack is installed — callers gate on `is_installed` first.
+    /// Whether error highlighting is on for `pack_id` — the default unless the
+    /// user opted out. Only meaningful when the pack is installed — callers gate
+    /// on `is_installed` first.
     pub fn errors_on(&self, pack_id: &str) -> bool {
-        self.errors_enabled.contains(pack_id)
+        !self.errors_disabled.contains(pack_id)
     }
 
-    /// Turn error highlighting on/off for `pack_id` (opt-in, default off).
+    /// Turn error highlighting on/off for `pack_id` (default on; `false` records
+    /// a per-pack opt-out).
     pub fn set_errors(&mut self, pack_id: &str, on: bool) {
         if on {
-            self.errors_enabled.insert(pack_id.to_string());
+            self.errors_disabled.remove(pack_id);
         } else {
-            self.errors_enabled.remove(pack_id);
+            self.errors_disabled.insert(pack_id.to_string());
         }
     }
 
@@ -93,22 +97,27 @@ mod tests {
     }
 
     #[test]
-    fn errors_opt_in_round_trips_and_defaults_off() {
+    fn errors_default_on_and_opt_out_round_trips() {
         let mut p = Plugins::default();
         p.install("json");
-        assert!(!p.errors_on("json"), "error highlighting must default OFF");
+        assert!(p.errors_on("json"), "error highlighting must default ON");
+        // Opt out → persists across a save/load round trip.
+        p.set_errors("json", false);
+        assert!(!p.errors_on("json"));
+        let back: Plugins = serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
+        assert!(!back.errors_on("json"));
+        // Opting back in clears the opt-out.
         p.set_errors("json", true);
         assert!(p.errors_on("json"));
-        let back: Plugins = serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
-        assert!(back.errors_on("json"));
-        // Old plugins.json without the field still parses (serde default).
+        // Old plugins.json without the field still parses → default on.
         let old: Plugins = serde_json::from_str(r#"{"installed":["json"]}"#).unwrap();
-        assert!(old.is_installed("json") && !old.errors_on("json"));
-        // Uninstall drops the opt-in too.
-        let mut q = p.clone();
-        q.uninstall("json");
-        assert!(!q.errors_on("json"));
+        assert!(old.is_installed("json") && old.errors_on("json"));
+        // Uninstall drops the opt-out → reinstall returns to the default (on).
+        let mut q = Plugins::default();
         q.install("json");
-        assert!(!q.errors_on("json"), "reinstall must not resurrect opt-in");
+        q.set_errors("json", false);
+        q.uninstall("json");
+        q.install("json");
+        assert!(q.errors_on("json"), "reinstall must return to default-on");
     }
 }

--- a/crates/kyde-config/src/plugins.rs
+++ b/crates/kyde-config/src/plugins.rs
@@ -14,6 +14,10 @@ pub struct Plugins {
     /// Set of installed pack ids (see `highlight::PACKS`).
     #[serde(default)]
     installed: BTreeSet<String>,
+    /// Pack ids with error highlighting opted in (a second gate on top of
+    /// `installed`: the pack's parse already runs, this adds the error walk).
+    #[serde(default)]
+    errors_enabled: BTreeSet<String>,
 }
 
 impl Plugins {
@@ -29,8 +33,25 @@ impl Plugins {
 
     /// Remove a pack from the installed set (its grammar is still compiled in, but the
     /// editor falls back to `PlainText` for that language until re-installed).
+    /// Also drops the pack's error-highlighting opt-in.
     pub fn uninstall(&mut self, pack_id: &str) {
         self.installed.remove(pack_id);
+        self.errors_enabled.remove(pack_id);
+    }
+
+    /// Whether error highlighting is opted in for `pack_id`. Only meaningful when
+    /// the pack is installed — callers gate on `is_installed` first.
+    pub fn errors_on(&self, pack_id: &str) -> bool {
+        self.errors_enabled.contains(pack_id)
+    }
+
+    /// Turn error highlighting on/off for `pack_id` (opt-in, default off).
+    pub fn set_errors(&mut self, pack_id: &str, on: bool) {
+        if on {
+            self.errors_enabled.insert(pack_id.to_string());
+        } else {
+            self.errors_enabled.remove(pack_id);
+        }
     }
 
     // ── persistence ───────────────────────────────────────────────
@@ -69,5 +90,25 @@ mod tests {
         let back: Plugins = serde_json::from_str(&json).unwrap();
         assert!(back.is_installed("json"));
         assert!(!back.is_installed("rust"));
+    }
+
+    #[test]
+    fn errors_opt_in_round_trips_and_defaults_off() {
+        let mut p = Plugins::default();
+        p.install("json");
+        assert!(!p.errors_on("json"), "error highlighting must default OFF");
+        p.set_errors("json", true);
+        assert!(p.errors_on("json"));
+        let back: Plugins = serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
+        assert!(back.errors_on("json"));
+        // Old plugins.json without the field still parses (serde default).
+        let old: Plugins = serde_json::from_str(r#"{"installed":["json"]}"#).unwrap();
+        assert!(old.is_installed("json") && !old.errors_on("json"));
+        // Uninstall drops the opt-in too.
+        let mut q = p.clone();
+        q.uninstall("json");
+        assert!(!q.errors_on("json"));
+        q.install("json");
+        assert!(!q.errors_on("json"), "reinstall must not resurrect opt-in");
     }
 }

--- a/crates/kyde-syntax/src/lib.rs
+++ b/crates/kyde-syntax/src/lib.rs
@@ -577,6 +577,83 @@ pub fn fold_regions(source: &str, lang: Lang) -> Vec<(usize, usize)> {
     out
 }
 
+/// Widen a zero-width range (a `MISSING` node) to cover one character so the UI
+/// has something to underline: the char at the position, or the one before it at
+/// end-of-source. Char-boundary safe; empty source stays empty.
+fn widen_if_empty(source: &str, r: std::ops::Range<usize>) -> std::ops::Range<usize> {
+    if r.start < r.end {
+        return r;
+    }
+    let start = r.start.min(source.len());
+    if let Some(c) = source[start..].chars().next() {
+        return start..start + c.len_utf8();
+    }
+    let prev = source[..start]
+        .chars()
+        .next_back()
+        .map_or(start, |c| start - c.len_utf8());
+    prev..start
+}
+
+/// Byte ranges the parser could not make sense of: `ERROR` nodes (unparseable
+/// source) plus `MISSING` nodes (a required token the parser inserted to
+/// recover, e.g. an unclosed brace), sorted and merged. Empty when the source
+/// parses cleanly or the language has no compiled-in grammar (`PlainText`, the
+/// builtin line-highlighters, feature-trimmed builds). Zero-width `MISSING`
+/// ranges are widened to one character so a squiggle can always be drawn.
+///
+/// ```
+/// use kyde_syntax::{error_ranges, Lang};
+/// assert!(error_ranges("{\"a\": 1}", Lang::Json).is_empty());
+/// assert!(!error_ranges("{\"a\" 1}", Lang::Json).is_empty());
+/// assert!(error_ranges("anything at all", Lang::PlainText).is_empty());
+/// ```
+pub fn error_ranges(source: &str, lang: Lang) -> Vec<std::ops::Range<usize>> {
+    let Some(grammar) = lang.grammar() else {
+        return Vec::new();
+    };
+    let mut parser = tree_sitter::Parser::new();
+    if parser.set_language(&grammar).is_err() {
+        return Vec::new();
+    }
+    let Some(tree) = parser.parse(source, None) else {
+        return Vec::new();
+    };
+    // Fast path: a clean parse (the overwhelmingly common case) never walks.
+    if !tree.root_node().has_error() {
+        return Vec::new();
+    }
+    let mut out: Vec<std::ops::Range<usize>> = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if node.is_error() || node.is_missing() {
+            // Children of an ERROR are partial re-parses of the broken region —
+            // one range covering the whole node is the honest report.
+            out.push(widen_if_empty(source, node.byte_range()));
+            continue;
+        }
+        // `has_error` is true iff an ERROR/MISSING exists in the subtree, so
+        // clean subtrees are pruned without visiting their children.
+        if !node.has_error() {
+            continue;
+        }
+        for i in 0..node.child_count() {
+            if let Some(c) = node.child(i) {
+                stack.push(c);
+            }
+        }
+    }
+    out.sort_by(|a, b| a.start.cmp(&b.start).then(a.end.cmp(&b.end)));
+    let mut merged: Vec<std::ops::Range<usize>> = Vec::new();
+    for r in out {
+        match merged.last_mut() {
+            Some(last) if r.start <= last.end => last.end = last.end.max(r.end),
+            _ => merged.push(r),
+        }
+    }
+    merged
+}
+
 /// Iterate `(byte_start, line)` over `source`, tracking byte offsets including '\n'.
 fn lines_with_offsets(source: &str) -> impl Iterator<Item = (usize, &str)> {
     let mut off = 0usize;
@@ -790,6 +867,64 @@ mod tests {
             .all(|&(s, e)| e > s));
         // no grammar → no folds
         assert!(fold_regions("a\nb\n", Lang::PlainText).is_empty());
+    }
+
+    #[test]
+    fn error_ranges_flags_invalid_source() {
+        // Extra comma is an ERROR node in the JSON grammar.
+        let bad = "{\"a\": 1,, \"b\": 2}";
+        let ranges = error_ranges(bad, Lang::Json);
+        assert!(!ranges.is_empty(), "invalid JSON produced no error ranges");
+        for r in &ranges {
+            assert!(r.start < r.end, "empty range {r:?}");
+            assert!(r.end <= bad.len(), "range {r:?} out of bounds");
+            assert!(
+                bad.is_char_boundary(r.start) && bad.is_char_boundary(r.end),
+                "range {r:?} splits a char"
+            );
+        }
+        // Clean parses stay empty.
+        assert!(error_ranges("{\"a\": 1}", Lang::Json).is_empty());
+        assert!(error_ranges("fn main() {}", Lang::Rust).is_empty());
+        // No grammar → no ranges, ever.
+        assert!(error_ranges("{{{{", Lang::PlainText).is_empty());
+        assert!(error_ranges("KEY=", Lang::Env).is_empty());
+    }
+
+    #[test]
+    fn error_ranges_widens_missing_at_eof() {
+        // Unclosed object → zero-width MISSING `}` at end-of-source, widened to
+        // cover the last character so the UI can draw a squiggle.
+        let src = "{\"a\": 1";
+        let ranges = error_ranges(src, Lang::Json);
+        assert!(!ranges.is_empty(), "unclosed JSON produced no error ranges");
+        assert!(ranges.iter().all(|r| r.start < r.end && r.end <= src.len()));
+        // Ranges are sorted and non-overlapping after the merge pass.
+        for w in ranges.windows(2) {
+            assert!(w[0].end <= w[1].start, "unmerged overlap: {ranges:?}");
+        }
+    }
+
+    /// Performance regression guard — see CLAUDE.md "Performance regression tests".
+    /// `error_ranges` runs on every keystroke (alongside `highlight` +
+    /// `fold_regions`) when a language's error highlighting is opted in, so it
+    /// must stay parse-speed. Two shapes: a big file with ONE error at the end
+    /// (the walk must prune clean subtrees, not visit ~4000 lines of nodes) and
+    /// an error-DENSE file (every statement broken — the walk visits everything).
+    #[test]
+    fn perf_error_ranges_large_files_stay_fast() {
+        let unit = "fn f(x: i32) -> i32 {\n    let y = x + 1;\n    y * 2\n}\n";
+        let mostly_clean = format!("{}fn broken(", unit.repeat(1000));
+        let error_dense = "let x = ;\n".repeat(4000);
+        let start = std::time::Instant::now();
+        let sparse = error_ranges(&mostly_clean, Lang::Rust);
+        let dense = error_ranges(&error_dense, Lang::Rust);
+        let elapsed = start.elapsed();
+        assert!(!sparse.is_empty() && !dense.is_empty());
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "error_ranges on ~4000-line files took {elapsed:?} (budget 2s) — perf regression?"
+        );
     }
 
     #[test]

--- a/crates/kyde-theme/src/lib.rs
+++ b/crates/kyde-theme/src/lib.rs
@@ -151,6 +151,9 @@ pub struct Theme {
     /// Syntax colour for operators + punctuation.
     #[serde(with = "hex")]
     pub syn_operator: Rgba,
+    /// Squiggly-underline colour for parse errors (error highlighting).
+    #[serde(with = "hex")]
+    pub syn_error: Rgba,
 
     // Font sizes (px). Not colours — plain numbers, hand-editable like the rest.
     /// Code surfaces: editor + diff panes + commit box.
@@ -278,6 +281,9 @@ fn apply_cvd(base: Theme, a: Cvd) -> Theme {
         syn_constant: base.text,
         syn_identifier: base.text,
         syn_operator: base.text,
+        // Error squiggle rides the conflict accent — same "needs attention" semantic,
+        // already tuned for the deficiency.
+        syn_error: c(a.conflict),
         ..base
     }
 }
@@ -333,6 +339,9 @@ impl Default for Theme {
             syn_constant: c(0xC77DBB),
             syn_identifier: c(0xD1D3D9),
             syn_operator: c(0xD1D3D9),
+            // Squiggle red — hotter than status_conflict so a parse error reads as
+            // "broken", not merely "conflicted".
+            syn_error: c(0xF75464),
 
             editor_font_size: 14.0,
             ui_font_size: 13.0,
@@ -399,6 +408,7 @@ impl Theme {
             syn_constant: c(0xA42F89),
             syn_identifier: c(0x1D1D1F),
             syn_operator: c(0x1D1D1F),
+            syn_error: c(0xD70015), // danger900, same family as status_conflict
 
             // Sizes inherited from the dark default; callers preserve the user's live values.
             editor_font_size: 14.0,

--- a/scripts/gen_lock.py
+++ b/scripts/gen_lock.py
@@ -7,7 +7,7 @@ path is argv[1]; line target is argv[2] (optional)."""
 import json
 import sys
 
-out = sys.argv[1]d
+out = sys.argv[1]
 target_lines = int(sys.argv[2]) if len(sys.argv) > 2 else 37000
 
 # Each package entry is ~6 lines when pretty-printed at indent=2.

--- a/scripts/gen_lock.py
+++ b/scripts/gen_lock.py
@@ -7,7 +7,7 @@ path is argv[1]; line target is argv[2] (optional)."""
 import json
 import sys
 
-out = sys.argv[1]
+out = sys.argv[1]d
 target_lines = int(sys.argv[2]) if len(sys.argv) > 2 else 37000
 
 # Each package entry is ~6 lines when pretty-printed at indent=2.

--- a/src/app.rs
+++ b/src/app.rs
@@ -555,6 +555,14 @@ impl Kyde {
         }
     }
 
+    /// Whether error highlighting (parse-error squiggles) is opted in for `lang`:
+    /// its pack installed AND the pack's error toggle on. `PlainText` and the
+    /// builtin line-highlighter langs have no pack → always false.
+    pub(crate) fn errors_enabled_for(&self, lang: Lang) -> bool {
+        lang.pack()
+            .is_some_and(|p| self.plugins.is_installed(p.id) && self.plugins.errors_on(p.id))
+    }
+
     /// Persist `rel`'s `text` to disk: through the repo's working tree in a git repo, else
     /// straight to disk under the project root (non-git Browse). Absolute paths (scratch
     /// files) write to themselves, since `join` keeps an absolute right-hand side. Returns

--- a/src/main.rs
+++ b/src/main.rs
@@ -2322,12 +2322,11 @@ fn apply_shot(view: &mut Kyde, name: &str, window: &mut Window, cx: &mut Context
                 .set_offset(gpui::point(px(0.0), px(-600.0 * editor::line_height_px())));
             cx.notify();
         }
-        // Browse an invalid JSON file (KYDE_SHOT_FILE) with the JSON pack installed AND its
-        // error-highlighting opt-in on → wavy red squiggles under the parse errors.
+        // Browse an invalid JSON file (KYDE_SHOT_FILE) with the JSON pack installed →
+        // wavy red squiggles under the parse errors (error highlighting is on by
+        // default for installed packs).
         "error-highlight" => {
             set_packs(view, &["json"]);
-            view.plugins.set_errors("json", true);
-            view.plugins.save();
             if let Ok(f) = std::env::var("KYDE_SHOT_FILE") {
                 view.open_file(PathBuf::from(f), cx);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2322,6 +2322,16 @@ fn apply_shot(view: &mut Kyde, name: &str, window: &mut Window, cx: &mut Context
                 .set_offset(gpui::point(px(0.0), px(-600.0 * editor::line_height_px())));
             cx.notify();
         }
+        // Browse an invalid JSON file (KYDE_SHOT_FILE) with the JSON pack installed AND its
+        // error-highlighting opt-in on → wavy red squiggles under the parse errors.
+        "error-highlight" => {
+            set_packs(view, &["json"]);
+            view.plugins.set_errors("json", true);
+            view.plugins.save();
+            if let Ok(f) = std::env::var("KYDE_SHOT_FILE") {
+                view.open_file(PathBuf::from(f), cx);
+            }
+        }
         // History view: the commit log for the current branch, first commit selected so the
         // changed-files list + read-only diff are populated.
         "history" => {

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -798,8 +798,12 @@ impl Kyde {
                 String::new()
             };
             let lang = self.effective_lang(&rel);
+            let errs = self.errors_enabled_for(lang);
             self.browse.editor.update(cx, |e, cx| {
                 e.line_numbers = true;
+                // Flag first so `set_content`'s recompute already parses (or skips)
+                // errors for the new file's opt-in.
+                e.set_error_highlight(errs, cx);
                 e.set_content(content, lang, cx);
             });
             // Point the editor at whichever scroll container it renders in, so caret-follow

--- a/src/views/modals.rs
+++ b/src/views/modals.rs
@@ -157,6 +157,30 @@ impl Kyde {
                                     .child(SharedString::from(pack_size(p.id))),
                             ),
                     )
+                    // Per-pack error-highlighting opt-in — only meaningful once the
+                    // grammar is active ("font" isn't a language, no parse to check).
+                    .when(installed && id != "font", |row| {
+                        let errs_on = self.plugins.errors_on(id);
+                        row.child(
+                            div()
+                                .flex()
+                                .flex_row()
+                                .items_center()
+                                .gap_2()
+                                .flex_none()
+                                .cursor_pointer()
+                                .text_size(px(11.0))
+                                .text_color(t.secondary_text)
+                                .child(checkbox_box(errs_on))
+                                .child("Error highlighting")
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(move |this, _e, _w, cx| {
+                                        this.toggle_pack_errors(id, cx);
+                                    }),
+                                ),
+                        )
+                    })
                     .child(btn)
                     .into_any_element()
             })
@@ -545,7 +569,11 @@ impl Kyde {
             self.plugins.save();
             // Re-highlight in place so the colors appear immediately — previously this only
             // set the lang, leaving the cached (plain) spans until the file was reopened.
-            self.browse.editor.update(cx, |e, cx| e.set_lang(lang, cx));
+            let errs = self.errors_enabled_for(lang);
+            self.browse.editor.update(cx, |e, cx| {
+                e.set_error_highlight(errs, cx);
+                e.set_lang(lang, cx);
+            });
         }
     }
 
@@ -595,7 +623,11 @@ impl Kyde {
             self.load_font_preview(cx);
         } else if let Some(rel) = self.browse.open_path.clone() {
             let eff = self.effective_lang(&rel);
-            self.browse.editor.update(cx, |e, cx| e.set_lang(eff, cx));
+            let errs = self.errors_enabled_for(eff);
+            self.browse.editor.update(cx, |e, cx| {
+                e.set_error_highlight(errs, cx);
+                e.set_lang(eff, cx);
+            });
         }
         cx.notify();
     }
@@ -614,7 +646,29 @@ impl Kyde {
             let lang = Lang::from_path(&rel);
             if lang.pack().map(|p| p.id) == Some(pack_id) {
                 let eff = self.effective_lang(&rel);
-                self.browse.editor.update(cx, |e, cx| e.set_lang(eff, cx));
+                let errs = self.errors_enabled_for(eff);
+                self.browse.editor.update(cx, |e, cx| {
+                    e.set_error_highlight(errs, cx);
+                    e.set_lang(eff, cx);
+                });
+            }
+        }
+        cx.notify();
+    }
+
+    /// Toggle a pack's error-highlighting opt-in (the second gate on top of
+    /// installed), persist it, and re-run the open file's error pass in place
+    /// so squiggles appear/clear immediately.
+    pub(crate) fn toggle_pack_errors(&mut self, pack_id: &str, cx: &mut Context<Self>) {
+        let on = !self.plugins.errors_on(pack_id);
+        self.plugins.set_errors(pack_id, on);
+        self.plugins.save();
+        if let Some(rel) = self.browse.open_path.clone() {
+            let eff = self.effective_lang(&rel);
+            if eff.pack().map(|p| p.id) == Some(pack_id) {
+                self.browse
+                    .editor
+                    .update(cx, |e, cx| e.set_error_highlight(on, cx));
             }
         }
         cx.notify();

--- a/src/widgets/editor/element.rs
+++ b/src/widgets/editor/element.rs
@@ -115,6 +115,11 @@ impl Element for EditorElement {
         let empty = editor.content.is_empty();
         // Cached on the editor (recomputed only on content change), not per paint.
         let spans: &[highlight::Span] = if empty { &[] } else { &editor.spans };
+        // Parse-error squiggles (empty unless the pack's opt-in is on — see
+        // `set_error_highlight`). Applied per visible row below, so off-screen
+        // rows never pay for the run splitting.
+        let errors: &[std::ops::Range<usize>] = if empty { &[] } else { &editor.error_ranges };
+        let error_color: Hsla = theme::get().syn_error.into();
 
         // Byte offset of every buffer line start — ONE pass over the content per frame.
         // (Previously the content was `split('\n')`-scanned 3-4× per frame — for a 37k-line
@@ -265,8 +270,13 @@ impl Element for EditorElement {
                         line_starts.push(start + seg);
                         visible_lines.push(b);
                         if on_screen(dr) {
-                            let s_runs =
-                                line_runs(seg_str, start + seg, spans, &font, default_color);
+                            let s_runs = apply_error_squiggles(
+                                line_runs(seg_str, start + seg, spans, &font, default_color),
+                                start + seg,
+                                seg_str.len(),
+                                errors,
+                                error_color,
+                            );
                             lines.insert(
                                 dr,
                                 window.text_system().shape_line(
@@ -288,7 +298,13 @@ impl Element for EditorElement {
                     gutter.push((dr, editor.folded.contains(&b)));
                 }
                 if on_screen(dr) {
-                    let runs = line_runs(line, start, spans, &font, default_color);
+                    let runs = apply_error_squiggles(
+                        line_runs(line, start, spans, &font, default_color),
+                        start,
+                        line.len(),
+                        errors,
+                        error_color,
+                    );
                     lines.insert(
                         dr,
                         window.text_system().shape_line(

--- a/src/widgets/editor/mod.rs
+++ b/src/widgets/editor/mod.rs
@@ -16,7 +16,7 @@ use gpui::{
     ElementId, ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle,
     Focusable, GlobalElementId, Hsla, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent,
     MouseUpEvent, Pixels, Point, ScrollHandle, ShapedLine, SharedString, Style, TextRun,
-    UTF16Selection, Window,
+    UTF16Selection, UnderlineStyle, Window,
 };
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
@@ -187,6 +187,13 @@ pub struct CodeEditor {
     /// change (in `recompute_folds`) — NOT per paint. This is the big-file win:
     /// scrolling/caret-moving no longer re-highlights the entire file each frame.
     spans: Vec<highlight::Span>,
+    /// Cached parse-error byte ranges (sorted, non-overlapping), recomputed with
+    /// `spans` — but ONLY when `errors_on`; empty otherwise, so editors without
+    /// the opt-in never pay the extra parse.
+    error_ranges: Vec<Range<usize>>,
+    /// Error highlighting opt-in for this editor's language (set by the app from
+    /// the pack's plugins.json toggle; default off).
+    errors_on: bool,
     /// Longest line length in bytes (recomputed on content change) — drives the element's
     /// content width so long lines scroll horizontally instead of clipping.
     max_line_len: usize,
@@ -305,6 +312,8 @@ impl CodeEditor {
             foldable_starts: HashSet::new(),
             compute_gen: 0,
             spans: Vec::new(),
+            error_ranges: Vec::new(),
+            errors_on: false,
             max_line_len: 0,
             line_layouts: HashMap::new(),
             display_rows: 0,
@@ -446,6 +455,7 @@ impl CodeEditor {
     fn recompute_folds(&mut self, cx: &mut Context<Self>) {
         if self.single_line || self.content.is_empty() {
             self.spans = Vec::new();
+            self.error_ranges = Vec::new();
             self.foldable = Vec::new();
             self.foldable_starts.clear();
             self.max_line_len = 0;
@@ -460,27 +470,42 @@ impl CodeEditor {
         // whole-file tree-sitter parse never blocks the UI (Zed-style async highlighting).
         let lines = self.content.bytes().filter(|&b| b == b'\n').count();
         const ASYNC_THRESHOLD: usize = 4000;
+        // Bump the generation on EVERY recompute (not just async ones) so a pending
+        // big-file background job can never land its stale spans on content that was
+        // since replaced via the inline path (big file → small file open).
+        self.compute_gen = self.compute_gen.wrapping_add(1);
         if lines < ASYNC_THRESHOLD {
             self.spans = highlight::highlight(&self.content, self.lang);
+            self.error_ranges = if self.errors_on {
+                highlight::error_ranges(&self.content, self.lang)
+            } else {
+                Vec::new()
+            };
             self.foldable = highlight::fold_regions(&self.content, self.lang);
             self.foldable_starts = self.foldable.iter().map(|r| r.0).collect();
             self.folded.retain(|l| self.foldable_starts.contains(l));
             return;
         }
         self.spans = Vec::new();
+        self.error_ranges = Vec::new();
         self.foldable = Vec::new();
         self.foldable_starts.clear();
-        self.compute_gen = self.compute_gen.wrapping_add(1);
         let gen = self.compute_gen;
         let content = self.content.clone();
         let lang = self.lang;
+        let errors_on = self.errors_on;
         cx.spawn(async move |this, cx| {
-            let (spans, foldable) = cx
+            let (spans, foldable, errors) = cx
                 .background_executor()
                 .spawn(async move {
                     (
                         highlight::highlight(&content, lang),
                         highlight::fold_regions(&content, lang),
+                        if errors_on {
+                            highlight::error_ranges(&content, lang)
+                        } else {
+                            Vec::new()
+                        },
                     )
                 })
                 .await;
@@ -488,6 +513,7 @@ impl CodeEditor {
                 if ed.compute_gen == gen {
                     // Still the current content → apply the highlight + folds.
                     ed.spans = spans;
+                    ed.error_ranges = errors;
                     ed.foldable_starts = foldable.iter().map(|r| r.0).collect();
                     ed.foldable = foldable;
                     ed.folded.retain(|l| ed.foldable_starts.contains(l));
@@ -497,6 +523,18 @@ impl CodeEditor {
             .ok();
         })
         .detach();
+    }
+
+    /// Toggle error highlighting (wavy squiggles under parse errors) for this
+    /// editor. The app derives `on` from the language pack's plugins.json opt-in;
+    /// idempotent, recomputes the cached ranges only when the flag flips.
+    pub fn set_error_highlight(&mut self, on: bool, cx: &mut Context<Self>) {
+        if self.errors_on == on {
+            return;
+        }
+        self.errors_on = on;
+        self.recompute_folds(cx);
+        cx.notify();
     }
 
     /// (Re)start the caret blink: show it now and bump the epoch so any prior blink loop exits,
@@ -1541,6 +1579,73 @@ pub fn line_runs(
     runs
 }
 
+/// Split `runs` (built by [`line_runs`] for the line at `line_start..line_start+line_len`)
+/// at error-range boundaries and give the error pieces a wavy underline — the
+/// squiggle then rides the normal `ShapedLine` paint, so virtualization is free
+/// (only visible rows are ever shaped). `errors` are whole-buffer byte ranges,
+/// sorted + non-overlapping (`highlight::error_ranges` guarantees both). Total
+/// run length is preserved, so shaping/metrics are unaffected.
+fn apply_error_squiggles(
+    runs: Vec<TextRun>,
+    line_start: usize,
+    line_len: usize,
+    errors: &[Range<usize>],
+    color: Hsla,
+) -> Vec<TextRun> {
+    let line_end = line_start + line_len;
+    // Binary-search the first error reaching this line (same trick as `line_runs`),
+    // then clamp the overlapping ones to line-local offsets.
+    let first = errors.partition_point(|r| r.end <= line_start);
+    let mut local: Vec<(usize, usize)> = Vec::new();
+    for r in &errors[first..] {
+        if r.start >= line_end {
+            break;
+        }
+        local.push((
+            r.start.max(line_start) - line_start,
+            r.end.min(line_end) - line_start,
+        ));
+    }
+    if local.is_empty() {
+        return runs;
+    }
+    let squiggle = UnderlineStyle {
+        thickness: px(1.0),
+        color: Some(color),
+        wavy: true,
+    };
+    let mut out: Vec<TextRun> = Vec::with_capacity(runs.len() + local.len() * 2);
+    let mut pos = 0usize; // line-local byte cursor
+    let mut li = 0usize; // index into `local` (monotonic — both walks are in order)
+    for run in runs {
+        let end = pos + run.len;
+        if run.len == 0 {
+            out.push(run); // preserve the empty-line sentinel run
+            continue;
+        }
+        let mut cur = pos;
+        while cur < end {
+            while li < local.len() && local[li].1 <= cur {
+                li += 1;
+            }
+            let (boundary, in_err) = match local.get(li) {
+                Some(&(es, ee)) if cur >= es => (ee.min(end), true),
+                Some(&(es, _)) => (es.min(end), false),
+                None => (end, false),
+            };
+            let mut piece = run.clone();
+            piece.len = boundary - cur;
+            if in_err {
+                piece.underline = Some(squiggle);
+            }
+            out.push(piece);
+            cur = boundary;
+        }
+        pos = end;
+    }
+    out
+}
+
 // ── fold mapping (pure, unit-testable — no gpui) ───────────────────
 // These operate only on the editor's data (`content` + `folded` set + `foldable`
 // regions), so the index arithmetic that drives the fold display can be tested
@@ -1780,6 +1885,109 @@ mod tests {
             elapsed < std::time::Duration::from_secs(2),
             "line_runs scanned linearly? {elapsed:?} for 200 frames × 60 rows over 200k spans"
         );
+    }
+
+    fn tfont() -> gpui::Font {
+        gpui::Font {
+            family: "monospace".into(),
+            features: Default::default(),
+            fallbacks: None,
+            weight: Default::default(),
+            style: Default::default(),
+        }
+    }
+
+    #[test]
+    fn error_squiggles_underline_exactly_the_error_bytes() {
+        let font = tfont();
+        let red: Hsla = gpui::rgb(0xff0000).into();
+        // One colored span (local 0..3) so the error range 2..5 crosses a run boundary.
+        let spans = vec![highlight::Span {
+            start: 100,
+            end: 103,
+            color: kyde_color::Color::rgb(0x00ff00),
+        }];
+        let line = "abcdefgh"; // line_start 100, len 8
+        let runs = line_runs(line, 100, &spans, &font, gpui::rgb(0xffffff).into());
+        let out = apply_error_squiggles(
+            runs,
+            100,
+            line.len(),
+            std::slice::from_ref(&(102..105)),
+            red,
+        );
+        // Total length preserved (shaping depends on it).
+        assert_eq!(out.iter().map(|r| r.len).sum::<usize>(), line.len());
+        // Underlined pieces cover exactly local bytes 2..5.
+        let mut pos = 0usize;
+        let mut underlined: Vec<(usize, usize)> = Vec::new();
+        for r in &out {
+            if let Some(u) = &r.underline {
+                assert!(u.wavy, "squiggle must be wavy");
+                assert_eq!(u.color, Some(red));
+                underlined.push((pos, pos + r.len));
+            }
+            pos += r.len;
+        }
+        assert_eq!(
+            underlined,
+            vec![(2, 3), (3, 5)],
+            "split at the span boundary"
+        );
+        // The colored piece keeps its syntax color under the squiggle.
+        assert_eq!(out.iter().filter(|r| r.underline.is_some()).count(), 2);
+    }
+
+    #[test]
+    fn error_squiggles_none_in_line_leaves_runs_untouched() {
+        let font = tfont();
+        let runs = line_runs("hello", 0, &[], &font, gpui::rgb(0xffffff).into());
+        let n = runs.len();
+        // Error entirely on a later line → unchanged (and no split allocations).
+        let out = apply_error_squiggles(
+            runs,
+            0,
+            5,
+            std::slice::from_ref(&(40..44)),
+            gpui::rgb(0xff0000).into(),
+        );
+        assert_eq!(out.len(), n);
+        assert!(out.iter().all(|r| r.underline.is_none()));
+    }
+
+    #[test]
+    fn error_squiggles_keep_empty_line_sentinel() {
+        let font = tfont();
+        // Empty line → line_runs emits the single zero-len sentinel run.
+        let runs = line_runs("", 10, &[], &font, gpui::rgb(0xffffff).into());
+        // A multi-line error range crossing the empty line clamps to zero width here.
+        let out = apply_error_squiggles(
+            runs,
+            10,
+            0,
+            std::slice::from_ref(&(9..12)),
+            gpui::rgb(0xff0000).into(),
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].len, 0);
+        assert!(out[0].underline.is_none());
+    }
+
+    #[test]
+    fn error_squiggles_cover_a_whole_line_of_a_multiline_error() {
+        let font = tfont();
+        let line = "broken";
+        let runs = line_runs(line, 20, &[], &font, gpui::rgb(0xffffff).into());
+        // Error spans lines 18..40 — every byte of this line squiggles.
+        let out = apply_error_squiggles(
+            runs,
+            20,
+            line.len(),
+            std::slice::from_ref(&(18..40)),
+            gpui::rgb(0xff0000).into(),
+        );
+        assert_eq!(out.iter().map(|r| r.len).sum::<usize>(), line.len());
+        assert!(out.iter().all(|r| r.underline.is_some()));
     }
 
     #[test]

--- a/src/widgets/editor/mod.rs
+++ b/src/widgets/editor/mod.rs
@@ -188,11 +188,13 @@ pub struct CodeEditor {
     /// scrolling/caret-moving no longer re-highlights the entire file each frame.
     spans: Vec<highlight::Span>,
     /// Cached parse-error byte ranges (sorted, non-overlapping), recomputed with
-    /// `spans` — but ONLY when `errors_on`; empty otherwise, so editors without
-    /// the opt-in never pay the extra parse.
+    /// `spans` — but ONLY when `errors_on`; empty otherwise, so editors with the
+    /// flag off never pay the extra parse.
     error_ranges: Vec<Range<usize>>,
-    /// Error highlighting opt-in for this editor's language (set by the app from
-    /// the pack's plugins.json toggle; default off).
+    /// Error highlighting for this editor's language — the app pushes it from the
+    /// pack's plugins.json toggle (on by default for installed packs, per-pack
+    /// opt-out). Editors nothing ever pushes to (commit box, single-line inputs,
+    /// diff/merge panes) stay false.
     errors_on: bool,
     /// Longest line length in bytes (recomputed on content change) — drives the element's
     /// content width so long lines scroll horizontally instead of clipping.


### PR DESCRIPTION
Closes #47.

## What
Wavy red squiggles under source the parser could not make sense of (tree-sitter `ERROR` + `MISSING` nodes) — e.g. the invalid JSON from the issue. **On by default for every installed pack**, with a per-pack opt-out: an "Error highlighting" checkbox on each installed pack's row in the Language Plugins window.

## How (speed cost, per the issue)
- **Per-lang gate**: rides the existing pack opt-in (nothing is ever parsed for uninstalled packs), plus a per-pack `errors_disabled` opt-out in plugins.json. Editors with the flag off never pay the extra parse; uninstalling a pack drops its opt-out (reinstall = defaults).
- **Virtualised**: squiggles ride the editor's existing `TextRun → ShapedLine` pipeline — `apply_error_squiggles` splits runs at error boundaries and sets a wavy underline, and runs only for on-screen rows (the same band the editor already shapes). Off-screen rows never pay.
- **Benchmarked**: new perf guard `perf_error_ranges_large_files_stay_fast` (sparse-error AND error-dense ~4000-line files; the walk prunes clean subtrees via `node.has_error()`), plus pure unit tests for the range walk, the run splitter, and the config round-trip.

## Pieces
- `kyde-syntax::error_ranges()` — pure; sorted+merged byte ranges, zero-width `MISSING` widened one char (char-boundary safe)
- `kyde-config::Plugins` — `errors_disabled` set (serde-default; old plugins.json parses → all on)
- `kyde-theme` — new `syn_error` key (dark `#F75464`, light `#D70015`, CVD variants ride the conflict accent)
- editor — ranges cached on `CodeEditor`, recomputed with spans (inline + async big-file paths); also fixes a latent stale-async race by bumping `compute_gen` on every recompute
- app — `errors_enabled_for()` applied on open / install / uninstall / toggle; `KYDE_SHOT=error-highlight` for deterministic captures

## Placement note
Squiggles mark tree-sitter's ERROR/MISSING node ranges exactly (pixel-verified against the parse tree). Error *recovery* decides those ranges, so occasionally the marked region is the expression the parser rejected rather than the human-perceived typo next to it (e.g. `out = sys.argv[1]d` marks `sys.argv[1]` — the parser kept `d` as the assignment's RHS). Token-exact diagnostics would need a real language server; out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)