### PR TITLE
feat: compare two files — side-by-side with a bidirectional apply gutter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,25 @@ a TWO-STAGE dialog:
   / `merge-compare` (manual) + `KYDE_SHOT_REPO=<clone with an in-progress conflicted merge>`
   (fixture built by scripts/screenshots.sh; region capture, 2 windows like rollback).
 
+## Compare view (src/views/compare.rs — issue #42)
+Compare any two files side-by-side in a native window (`ModalKind::Compare`, opens at the
+main window's bounds like Diff/Merge). Entry points: **cmd-click two files** in the Browse
+tree (multi-select, `BrowseView.multi_selected` — ordered, cleared by any plain click or
+project switch; rows render selected) → right-click → **Compare Selected**; or right-click
+a non-active **tab** → **Compare with Current Tab** (active tab = left). `CompareView`
+(`compare` on `Kyde`): two read-only `CodeEditor` panes row-aligned via the diff_view
+helpers (`diff_line_bgs`/`diff_word_bgs`/`diff_fillers`) + one shared `ScrollHandle` (the
+merge Compare Contents pattern); per-side `effective_lang` syntax. The center gutter puts
+**« »** on every hunk's first aligned row (from `aligned_rows`): `»` copies the LEFT
+side's lines into the right FILE, `«` the reverse — both directions come from
+`FileDiff::partial_new_content` (right←left = all hunks except i; left←right = only i —
+outside hunks the sides are identical). The header offers whole-file `«`/`»` (make one
+side match the other) + a difference count. Applying WRITES the target file
+(`write_open_file` — repo/root/absolute-scratch all work), reloads a clean open Browse
+buffer showing it, re-diffs in place, and refreshes git status. Smoke test:
+`compare_applies_hunks_both_directions`. Debug shot: `KYDE_SHOT=compare` +
+`KYDE_SHOT_FILE`/`KYDE_SHOT_FILE_B`.
+
 ## Window chrome — native blend + activity rail (render)
 The window uses a **transparent titlebar** (`WindowOptions.titlebar = TitlebarOptions {
 appears_transparent: true, traffic_light_position: point(16,16) }`) so our `frame_bg` chrome

--- a/src/app.rs
+++ b/src/app.rs
@@ -274,6 +274,8 @@ impl Kyde {
             history: HistoryView::new(cx),
             merge_win: None,
             merge: MergeView::new(cx),
+            compare_win: None,
+            compare: CompareView::new(cx),
             term: TermState::new(),
         };
         me.refresh(cx);
@@ -567,7 +569,7 @@ impl Kyde {
     /// straight to disk under the project root (non-git Browse). Absolute paths (scratch
     /// files) write to themselves, since `join` keeps an absolute right-hand side. Returns
     /// the error so callers can surface it (a swallowed write means silently-lost edits).
-    fn write_open_file(&self, rel: &std::path::Path, text: &str) -> anyhow::Result<()> {
+    pub(crate) fn write_open_file(&self, rel: &std::path::Path, text: &str) -> anyhow::Result<()> {
         if let Some(repo) = self.repo() {
             repo.save_file(rel, text)?;
         } else if let Some(root) = self.repo_root.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -895,6 +895,9 @@ struct BrowseView {
     /// Highlighted row in the tree (file OR folder); drives the breadcrumb.
     /// Distinct from `open_path` so selecting a folder doesn't change the editor.
     selected_path: Option<PathBuf>,
+    /// Cmd-clicked FILE rows (ordered). Exactly two → the right-click menu
+    /// offers "Compare Selected" (issue #42). Cleared by any plain click.
+    multi_selected: Vec<PathBuf>,
     /// Scroll position of the tree, so "Select Opened File in Tree" can scroll an
     /// off-screen row into view.
     tree_scroll: ScrollHandle,
@@ -945,6 +948,7 @@ impl BrowseView {
             scratches: Vec::new(),
             tab_scroll: ScrollHandle::new(),
             selected_path: None,
+            multi_selected: Vec::new(),
             tree_scroll: ScrollHandle::new(),
             editor,
             editor_scroll: ScrollHandle::new(),
@@ -1448,6 +1452,11 @@ struct Kyde {
     /// Merge state (in-progress banner + the 3-pane resolve window — see `MergeView`).
     merge: MergeView,
 
+    /// Compare-two-files — its own native window (`ModalKind::Compare`).
+    compare_win: Option<gpui::WindowHandle<ModalWindow>>,
+    /// Compare state (paths + aligned panes — see `CompareView`).
+    compare: CompareView,
+
     // Bottom terminal panel — control state + (feature-gated) PTY tab views, grouped into
     // one sub-struct (see `TermState`).
     term: TermState,
@@ -1467,6 +1476,46 @@ enum ModalKind {
     Settings,
     /// 3-pane merge-conflict resolution (yours | result | theirs).
     Merge,
+    /// Two-file side-by-side compare with an apply gutter (issue #42).
+    Compare,
+}
+
+/// Compare-two-files state (issue #42): the chosen paths, the computed diff, and
+/// two read-only aligned panes sharing one scroll — the merge Compare Contents
+/// pattern, plus a center gutter that applies hunks either direction.
+struct CompareView {
+    /// Left file (repo-relative, or absolute for scratches).
+    left_path: Option<PathBuf>,
+    /// Right file.
+    right_path: Option<PathBuf>,
+    /// The current diff (left = old, right = new). `None` until both sides load.
+    diff: Option<FileDiff>,
+    /// Left pane (read-only; applying writes files and reloads).
+    left: Entity<CodeEditor>,
+    /// Right pane.
+    right: Entity<CodeEditor>,
+    /// Shared scroll for both panes + the gutter.
+    scroll: ScrollHandle,
+}
+
+impl CompareView {
+    fn new(cx: &mut Context<Kyde>) -> Self {
+        let mk = |cx: &mut Context<Kyde>| {
+            cx.new(|cx| {
+                let mut e = CodeEditor::read_only(cx, String::new(), Lang::PlainText);
+                e.line_numbers = true;
+                e
+            })
+        };
+        Self {
+            left_path: None,
+            right_path: None,
+            diff: None,
+            left: mk(cx),
+            right: mk(cx),
+            scroll: ScrollHandle::new(),
+        }
+    }
 }
 
 /// Which category the Settings window's sidebar has selected. Drives `render_settings_body`'s
@@ -1542,6 +1591,7 @@ impl Render for ModalWindow {
             ModalKind::ClearData => k.render_clear_data_body(kcx),
             ModalKind::Settings => k.render_settings_body(kcx),
             ModalKind::Merge => k.render_merge_body(kcx),
+            ModalKind::Compare => k.render_compare_body(kcx),
         });
         div()
             .track_focus(&self.focus)
@@ -2360,6 +2410,17 @@ fn apply_shot(view: &mut Kyde, name: &str, window: &mut Window, cx: &mut Context
                 );
             }
         }
+        // The Compare window over two fixture files (KYDE_SHOT_FILE ↔ KYDE_SHOT_FILE_B):
+        // side-by-side aligned panes + the center apply gutter.
+        "compare" => {
+            set_packs(view, &["json"]);
+            if let (Ok(a), Ok(b)) = (
+                std::env::var("KYDE_SHOT_FILE"),
+                std::env::var("KYDE_SHOT_FILE_B"),
+            ) {
+                view.open_compare(PathBuf::from(a), PathBuf::from(b), cx);
+            }
+        }
         // History view: the commit log for the current branch, first commit selected so the
         // changed-files list + read-only diff are populated.
         "history" => {
@@ -2941,6 +3002,42 @@ mod gpui_smoke_tests {
                     "{\n  \"a\": 2,\n  \"b\": 1\n}",
                     "no sorting outside Browse"
                 );
+            })
+            .unwrap();
+    }
+
+    /// Compare two files (issue #42): `open_compare` diffs them, the gutter's
+    /// apply copies a hunk either direction (writing the TARGET file to disk and
+    /// re-diffing in place), and the pair converges to zero differences.
+    #[gpui::test]
+    fn compare_applies_hunks_both_directions(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        std::fs::write(dir.join("a.txt"), "one\ntwo\nthree\n").unwrap();
+        std::fs::write(dir.join("b.txt"), "one\nTWO\nthree\nfour\n").unwrap();
+        handle
+            .update(cx, |k, _w, cx| {
+                k.open_compare(PathBuf::from("a.txt"), PathBuf::from("b.txt"), cx);
+                let d = k.compare.diff.as_ref().unwrap();
+                assert_eq!(d.hunks.len(), 2, "two→TWO + the trailing four");
+                // « — the LEFT file takes the right side's hunk 0 (two → TWO).
+                k.compare_apply_hunk(0, false, cx);
+                assert_eq!(
+                    std::fs::read_to_string(dir.join("a.txt")).unwrap(),
+                    "one\nTWO\nthree\n"
+                );
+                assert_eq!(
+                    k.compare.diff.as_ref().unwrap().hunks.len(),
+                    1,
+                    "re-diffed after the apply"
+                );
+                // » — the RIGHT file takes the left side for the remaining hunk
+                // (drops its extra "four" line).
+                k.compare_apply_hunk(0, true, cx);
+                assert_eq!(
+                    std::fs::read_to_string(dir.join("b.txt")).unwrap(),
+                    "one\nTWO\nthree\n"
+                );
+                assert!(k.compare.diff.as_ref().unwrap().hunks.is_empty());
             })
             .unwrap();
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -744,6 +744,19 @@ impl Kyde {
                         }),
                     ));
                 }
+                // Exactly two cmd-selected files → side-by-side compare (issue #42).
+                if self.browse.multi_selected.len() == 2 {
+                    let (a, b) = (
+                        self.browse.multi_selected[0].clone(),
+                        self.browse.multi_selected[1].clone(),
+                    );
+                    panel = panel.child(item("Compare Selected").on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _e, _w, cx| {
+                            this.open_compare(a.clone(), b.clone(), cx);
+                        }),
+                    ));
+                }
                 // Commit/Rollback only make sense when there are changes under the path.
                 if self.has_changes_under(p) {
                     panel = panel
@@ -796,7 +809,7 @@ impl Kyde {
             MenuTarget::Tab(idx) => {
                 let idx = *idx;
                 let reveal = self.browse.open_tabs.get(idx).cloned();
-                panel
+                panel = panel
                     .child(item("Close").on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |this, _e, _w, cx| this.close_tab(idx, cx)),
@@ -808,15 +821,32 @@ impl Kyde {
                     .child(item("Close Tabs to the Right").on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |this, _e, _w, cx| this.close_tabs_right(idx, cx)),
-                    ))
-                    .child(item("Reveal in Finder").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |this, _e, _w, cx| {
-                            if let Some(p) = reveal.clone() {
-                                this.reveal_in_os(&p, cx);
-                            }
-                        }),
-                    ))
+                    ));
+                // Compare this tab's file against the ACTIVE tab's (issue #42) —
+                // only offered on a non-active tab, where the pair is meaningful.
+                if let (Some(tab), Some(active)) = (
+                    self.browse.open_tabs.get(idx).cloned(),
+                    self.browse.open_path.clone(),
+                ) {
+                    if tab != active {
+                        panel = panel.child(item("Compare with Current Tab").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _e, _w, cx| {
+                                // Active tab on the left (the "current" baseline),
+                                // the clicked tab on the right.
+                                this.open_compare(active.clone(), tab.clone(), cx);
+                            }),
+                        ));
+                    }
+                }
+                panel.child(item("Reveal in Finder").on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _e, _w, cx| {
+                        if let Some(p) = reveal.clone() {
+                            this.reveal_in_os(&p, cx);
+                        }
+                    }),
+                ))
             }
             MenuTarget::CommitPath(path, _is_dir) => {
                 let path = path.clone();

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -347,7 +347,8 @@ impl Kyde {
                         .into()
                 };
                 let expanded = self.browse.expanded.contains(&r.path);
-                let selected = self.browse.selected_path.as_ref() == Some(&r.path);
+                let selected = self.browse.selected_path.as_ref() == Some(&r.path)
+                    || self.browse.multi_selected.contains(&r.path);
                 let (p_act, p_ctx) = (r.path.clone(), r.path.clone());
                 let is_dir = r.is_dir;
                 // Color changed files by their git status (modified/added/…), matching the
@@ -369,9 +370,37 @@ impl Kyde {
                     None,
                     None,
                     move |this, e, window, cx| {
+                        // Cmd-click on a FILE toggles it in the multi-selection (for
+                        // "Compare Selected" — issue #42) without opening it. The
+                        // previously highlighted file seeds the set, so cmd-clicking a
+                        // second file selects the natural pair.
+                        if !is_dir && e.modifiers.platform {
+                            if let Some(i) =
+                                this.browse.multi_selected.iter().position(|p| p == &p_act)
+                            {
+                                this.browse.multi_selected.remove(i);
+                            } else {
+                                if this.browse.multi_selected.is_empty() {
+                                    if let Some(prev) =
+                                        this.browse.selected_path.clone().filter(|p| {
+                                            p != &p_act
+                                                && (this.browse.all_files.contains(p)
+                                                    || this.browse.scratches.contains(p))
+                                        })
+                                    {
+                                        this.browse.multi_selected.push(prev);
+                                    }
+                                }
+                                this.browse.multi_selected.push(p_act.clone());
+                            }
+                            this.browse.selected_path = Some(p_act.clone());
+                            cx.notify();
+                            return;
+                        }
                         // Folders toggle expansion. Files (VS Code-style): single click opens in
                         // the temporary *preview* tab (reused by the next single-click), double
                         // click opens a permanent tab.
+                        this.browse.multi_selected.clear();
                         this.browse.selected_path = Some(p_act.clone());
                         // Focus the app root so the "Kyde"-context Backspace (delete) binding
                         // is live on the selected row. (open_file/preview_file re-focus the

--- a/src/views/compare.rs
+++ b/src/views/compare.rs
@@ -1,0 +1,402 @@
+//! Compare-two-files (issue #42): a native window with two read-only aligned
+//! panes (the merge Compare Contents pattern) plus a center gutter that applies
+//! any hunk in EITHER direction — `»` copies the left side's lines into the
+//! right file, `«` copies the right side's into the left. Applying writes the
+//! target file to disk (the panes are views, not buffers) and re-diffs.
+
+use crate::*;
+
+/// Center gutter width — two 22px controls + breathing room (matches the merge
+/// view's gutters).
+const COMPARE_GUTTER_W: f32 = 56.0;
+
+impl Kyde {
+    /// Open (or re-focus) the Compare window for `left` ↔ `right`. Paths are
+    /// repo-relative (or absolute for scratch files), like every open-file path.
+    pub(crate) fn open_compare(&mut self, left: PathBuf, right: PathBuf, cx: &mut Context<Self>) {
+        let name = |p: &PathBuf| {
+            p.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        };
+        let title = format!("Compare: {} ↔ {}", name(&left), name(&right));
+        self.compare.left_path = Some(left);
+        self.compare.right_path = Some(right);
+        self.reload_compare(true, cx);
+        self.open_modal_window(ModalKind::Compare, title, 1200.0, 760.0, cx);
+    }
+
+    /// Read one side's current text from disk (same resolution as `open_file`:
+    /// absolute = scratch, else through the repo / project root).
+    fn read_compare_side(&self, rel: &PathBuf) -> String {
+        if rel.is_absolute() {
+            return std::fs::read_to_string(rel).unwrap_or_default();
+        }
+        if let Some(repo) = self.repo() {
+            return repo.working_content(rel).ok().unwrap_or_default();
+        }
+        self.repo_root
+            .as_ref()
+            .and_then(|root| std::fs::read_to_string(root.join(rel)).ok())
+            .unwrap_or_default()
+    }
+
+    /// (Re)load both panes from disk and re-diff: contents, per-side syntax,
+    /// diff decorations (line tints, word emphasis, alignment fillers), shared
+    /// scroll. `park` scrolls to just above the first hunk (window open only —
+    /// an apply keeps the user's scroll position).
+    pub(crate) fn reload_compare(&mut self, park: bool, cx: &mut Context<Self>) {
+        let (Some(lp), Some(rp)) = (
+            self.compare.left_path.clone(),
+            self.compare.right_path.clone(),
+        ) else {
+            return;
+        };
+        let lt = self.read_compare_side(&lp);
+        let rt = self.read_compare_side(&rp);
+        let d = FileDiff::compute(&lt, &rt);
+        let first = d.hunks.first().map(|h| h.old_range.start);
+        let (lbg, rbg) = diff_line_bgs(&d);
+        let (lw, rw) = diff_word_bgs(&d);
+        let (lf, lf_end, rf, rf_end) = diff_fillers(&d);
+        let (l_lang, r_lang) = (self.effective_lang(&lp), self.effective_lang(&rp));
+        let t = theme::get();
+        self.compare.left.update(cx, |e, cx| {
+            e.gutter_right = true; // numbers toward the center gutter, like the diff base pane
+            e.line_bg = lbg;
+            e.word_bg = lw;
+            e.word_bg_color = t.diff_word_old_bg;
+            e.filler = lf;
+            e.filler_end = lf_end;
+            e.set_content(lt, l_lang, cx);
+        });
+        self.compare.right.update(cx, |e, cx| {
+            e.line_bg = rbg;
+            e.word_bg = rw;
+            e.word_bg_color = t.diff_word_new_bg;
+            e.filler = rf;
+            e.filler_end = rf_end;
+            e.set_content(rt, r_lang, cx);
+        });
+        let sh = self.compare.scroll.clone();
+        self.compare
+            .left
+            .update(cx, |e, _| e.set_scroll_handle(sh.clone()));
+        self.compare
+            .right
+            .update(cx, |e, _| e.set_scroll_handle(sh));
+        if park {
+            let row = first.unwrap_or(0).saturating_sub(SCROLL_CONTEXT_ROWS) as f32;
+            self.compare
+                .scroll
+                .set_offset(gpui::point(px(0.0), px(-row * editor::line_height_px())));
+        }
+        self.compare.diff = Some(d);
+        cx.notify();
+    }
+
+    /// Copy hunk `hi` across: `to_right` = the right file takes the LEFT side's
+    /// lines for that hunk, else the left file takes the right's. Outside hunks
+    /// the sides are identical, so both directions come from
+    /// `partial_new_content`: right←left = every hunk EXCEPT `hi` applied;
+    /// left←right = ONLY `hi` applied. Writes the target file and re-diffs.
+    pub(crate) fn compare_apply_hunk(&mut self, hi: usize, to_right: bool, cx: &mut Context<Self>) {
+        let Some(d) = self.compare.diff.as_ref() else {
+            return;
+        };
+        let text = if to_right {
+            d.partial_new_content(|j| j != hi)
+        } else {
+            d.partial_new_content(|j| j == hi)
+        };
+        self.compare_write_side(to_right, &text, cx);
+    }
+
+    /// Make one whole side match the other (the header's `»`/`«` All buttons).
+    pub(crate) fn compare_apply_all(&mut self, to_right: bool, cx: &mut Context<Self>) {
+        let Some(d) = self.compare.diff.as_ref() else {
+            return;
+        };
+        if d.hunks.is_empty() {
+            return;
+        }
+        let text = if to_right {
+            d.partial_new_content(|_| false) // right becomes the left text
+        } else {
+            d.partial_new_content(|_| true) // left becomes the right text
+        };
+        self.compare_write_side(to_right, &text, cx);
+    }
+
+    /// Persist an apply's result to the target side's file, refresh the open
+    /// editor if it shows that file (never clobbering unsaved edits), and
+    /// re-diff the panes in place.
+    fn compare_write_side(&mut self, to_right: bool, text: &str, cx: &mut Context<Self>) {
+        let target = if to_right {
+            self.compare.right_path.clone()
+        } else {
+            self.compare.left_path.clone()
+        };
+        let Some(target) = target else { return };
+        if let Err(e) = self.write_open_file(&target, text) {
+            self.fail("Compare apply", e);
+            cx.notify();
+            return;
+        }
+        // The applied file may be open in Browse — reload it unless it has
+        // unsaved edits (the reload_external never-clobber rule).
+        if self.browse.open_path.as_ref() == Some(&target) && !self.browse.editor.read(cx).dirty {
+            let lang = self.effective_lang(&target);
+            let content = text.to_string();
+            self.browse
+                .editor
+                .update(cx, |e, cx| e.set_content(content, lang, cx));
+        }
+        self.reload_compare(false, cx);
+        self.refresh(cx); // the write changed git status
+    }
+
+    /// The Compare window body: header (file names + whole-file apply buttons +
+    /// difference count) over the two aligned panes and the center apply gutter.
+    pub(crate) fn render_compare_body(&mut self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let t = theme::get();
+        let ui = theme::font::UI_FAMILY;
+        let fs = px(t.editor_font_size);
+        let row_h = px(editor::line_height_px());
+        let Some(d) = self.compare.diff.as_ref() else {
+            return div().into_any_element();
+        };
+
+        // Per-hunk gutter controls at each hunk's first aligned display row.
+        let rows = aligned_rows(d);
+        let total_h = row_h * rows.len() as f32;
+        let hunk_rows: Vec<(usize, usize)> = rows
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| r.hunk_start)
+            .filter_map(|(row, r)| r.hunk.map(|h| (row, h)))
+            .collect();
+        let ctl = |id: String,
+                   glyph: &'static str,
+                   tip: &'static str,
+                   hi: usize,
+                   to_right: bool,
+                   cx: &mut Context<Self>| {
+            let tip = SharedString::from(tip);
+            div()
+                .id(SharedString::from(id))
+                .flex()
+                .items_center()
+                .justify_center()
+                .size(px(22.0))
+                .rounded_sm()
+                .text_size(px(17.0))
+                .line_height(px(17.0))
+                .text_color(t.line_number)
+                .hover(|s| s.bg(t.bg_light).text_color(t.primary))
+                .cursor_pointer()
+                .tooltip(move |_w, cx| cx.new(|_| Tip(tip.clone())).into())
+                .child(glyph)
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _e, _w, cx| {
+                        cx.stop_propagation();
+                        this.compare_apply_hunk(hi, to_right, cx);
+                    }),
+                )
+        };
+        let mut ctls: Vec<gpui::AnyElement> = Vec::new();
+        for &(row, hi) in &hunk_rows {
+            ctls.push(
+                div()
+                    .absolute()
+                    .top(row_h * row as f32)
+                    .left_0()
+                    .right_0()
+                    .h(row_h)
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .justify_center()
+                    .gap_0p5()
+                    .child(ctl(
+                        format!("cmp-left-{hi}"),
+                        "«",
+                        "Copy this change to the left file",
+                        hi,
+                        false,
+                        cx,
+                    ))
+                    .child(ctl(
+                        format!("cmp-right-{hi}"),
+                        "»",
+                        "Copy this change to the right file",
+                        hi,
+                        true,
+                        cx,
+                    ))
+                    .into_any_element(),
+            );
+        }
+        let scroll_y = self.compare.scroll.offset().y;
+        let gutter = div()
+            .id("compare-gutter")
+            .w(px(COMPARE_GUTTER_W))
+            .flex_none()
+            .h_full()
+            .overflow_hidden()
+            .bg(t.diff_separator_bg)
+            .border_l(px(1.0))
+            .border_r(px(1.0))
+            .border_color(t.divider)
+            .child(
+                div()
+                    .relative()
+                    .w_full()
+                    .h(total_h)
+                    .top(scroll_y)
+                    .children(ctls),
+            );
+
+        // Panes: shared scroll, content width for horizontal overflow.
+        let lw = self.compare.left.read(cx).content_width();
+        let rw = self.compare.right.read(cx).content_width();
+        let pane = |id: &'static str, w: f32, ed: gpui::AnyElement, scroll: &ScrollHandle| {
+            div()
+                .flex_1()
+                .min_w_0()
+                .h_full()
+                .bg(t.main_bg)
+                .font_family(theme::font::FAMILY)
+                .text_size(fs)
+                .text_color(t.text)
+                .child(
+                    div()
+                        .id(id)
+                        .h_full()
+                        .w_full()
+                        .overflow_scroll()
+                        .track_scroll(scroll)
+                        .child(div().w(px(w)).child(ed)),
+                )
+        };
+        let scroll = self.compare.scroll.clone();
+
+        // Header: file names over their panes, whole-file apply + diff count in
+        // the middle over the gutter column.
+        let path_label = |p: Option<&PathBuf>| {
+            p.map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        };
+        let n = d.hunks.len();
+        let count = if n == 0 {
+            "No differences".to_string()
+        } else {
+            format!("{n} difference{}", if n == 1 { "" } else { "s" })
+        };
+        let all = |id: &'static str,
+                   glyph: &'static str,
+                   tip: &'static str,
+                   to_right: bool,
+                   cx: &mut Context<Self>| {
+            let tip = SharedString::from(tip);
+            div()
+                .id(id)
+                .px_2()
+                .py_0p5()
+                .rounded_sm()
+                .border_1()
+                .border_color(t.divider)
+                .text_color(t.secondary_text)
+                .hover(|s| s.bg(t.bg_light).text_color(t.primary))
+                .cursor_pointer()
+                .tooltip(move |_w, cx| cx.new(|_| Tip(tip.clone())).into())
+                .child(glyph)
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _e, _w, cx| {
+                        this.compare_apply_all(to_right, cx);
+                    }),
+                )
+        };
+        let header = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_2()
+            .px_3()
+            .py_2()
+            .font_family(ui)
+            .text_size(px(t.ui_font_size))
+            .border_b(px(1.0))
+            .border_color(t.divider)
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .text_color(t.text)
+                    .child(SharedString::from(path_label(
+                        self.compare.left_path.as_ref(),
+                    ))),
+            )
+            .child(all(
+                "cmp-all-left",
+                "«",
+                "Copy ALL changes to the left file",
+                false,
+                cx,
+            ))
+            .child(
+                div()
+                    .flex_none()
+                    .text_color(t.secondary_text)
+                    .child(SharedString::from(count)),
+            )
+            .child(all(
+                "cmp-all-right",
+                "»",
+                "Copy ALL changes to the right file",
+                true,
+                cx,
+            ))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .text_right()
+                    .text_color(t.text)
+                    .child(SharedString::from(path_label(
+                        self.compare.right_path.as_ref(),
+                    ))),
+            );
+
+        div()
+            .size_full()
+            .flex()
+            .flex_col()
+            .child(header)
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .flex_1()
+                    .min_h_0()
+                    .child(pane(
+                        "compare-left",
+                        lw,
+                        self.compare.left.clone().into_any_element(),
+                        &scroll,
+                    ))
+                    .child(gutter)
+                    .child(pane(
+                        "compare-right",
+                        rw,
+                        self.compare.right.clone().into_any_element(),
+                        &scroll,
+                    )),
+            )
+            .into_any_element()
+    }
+}

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -4,6 +4,7 @@
 mod branch;
 mod browse;
 mod commit;
+mod compare;
 mod diff_view;
 mod file_ops;
 mod find;

--- a/src/views/modals.rs
+++ b/src/views/modals.rs
@@ -441,6 +441,7 @@ impl Kyde {
             ModalKind::ClearData => &mut self.clear_data_win,
             ModalKind::Settings => &mut self.settings_win,
             ModalKind::Merge => &mut self.merge_win,
+            ModalKind::Compare => &mut self.compare_win,
         }
     }
 
@@ -471,9 +472,12 @@ impl Kyde {
         // The Diff + Merge modals open at the MAIN window's bounds (captured each frame in
         // `impl Render for Kyde`) so they're as big as the editor and land over it — NOT the
         // focused window's, which may be another modal (e.g. Rollback) they were launched from.
-        let main_bounds = matches!(kind, ModalKind::Diff | ModalKind::Merge)
-            .then_some(self.main_window_bounds)
-            .flatten();
+        let main_bounds = matches!(
+            kind,
+            ModalKind::Diff | ModalKind::Merge | ModalKind::Compare
+        )
+        .then_some(self.main_window_bounds)
+        .flatten();
         cx.spawn(async move |this, cx| {
             let opened = cx.update(|cx| {
                 // Center on the display the main window is on (else gpui picks the primary

--- a/src/views/projects_view.rs
+++ b/src/views/projects_view.rs
@@ -515,6 +515,7 @@ impl Kyde {
             self.browse.open_path = None;
             self.browse.open_tabs.clear();
             self.browse.preview_tab = None;
+            self.browse.multi_selected.clear();
             self.selected = None;
             self.browse.expanded.clear();
             self.browse.expanded.insert(PathBuf::new()); // root folder visible by default
@@ -541,6 +542,7 @@ impl Kyde {
             self.browse.open_path = None;
             self.browse.open_tabs.clear();
             self.browse.preview_tab = None;
+            self.browse.multi_selected.clear();
             self.selected = None;
         } else {
             // Prefer the tab that shifted into this slot, else the previous one.


### PR DESCRIPTION
Closes #42.

## What
A **Compare window** for any two files: side-by-side row-aligned panes (diff tints, word-level emphasis, alignment fillers, shared scroll, per-side syntax highlighting) with a **center gutter that applies hunks in either direction** — `»` copies the left side's lines into the right file, `«` the reverse — plus whole-file `«`/`»` in the header and a live difference count. The merge view's interaction model, applied to arbitrary file pairs.

## Entry points
- **Browse tree**: ⌘-click multi-selects files (rows highlight; a plain click or project switch clears). With exactly two selected, right-click → **Compare Selected**.
- **Tabs**: right-click a non-active tab → **Compare with Current Tab** (the active tab is the left/baseline side).

## How applying works
No new diff primitives: with `FileDiff::compute(left, right)`, both directions fall out of `partial_new_content` — outside hunks the sides are identical, so *right ← left hunk i* = every hunk except `i` applied, and *left ← right hunk i* = only `i` applied. Each apply writes the target file to disk, reloads a clean open Browse buffer showing that file (never clobbers unsaved edits), re-diffs the panes in place (scroll preserved), and refreshes git status. Works for repo files, non-git project files, and absolute-path scratches.

## Safety / tests
- Panes are read-only `CodeEditor`s — the files on disk are the source of truth.
- Gutter controls are positioned from `aligned_rows` (the same geometry the panes render), so buttons always sit on their hunk.
- Smoke test `compare_applies_hunks_both_directions` drives both directions to convergence on disk. `KYDE_SHOT=compare` (+ `KYDE_SHOT_FILE`/`KYDE_SHOT_FILE_B`) for deterministic captures.
- fmt + clippy `--workspace --all-targets --all-features -D warnings` + 21 test suites + zero-feature build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)