### PR TITLE
feat: ⌘-click imports to open the referenced file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,28 +518,55 @@ CVD variants ride the conflict accent) — the squiggle paints inside the normal
 appear wherever the editor's flag is on (Browse; diff/merge panes never set it).
 Debug shot: `KYDE_SHOT=error-highlight` + `KYDE_SHOT_FILE=<invalid .json>`.
 
-### ⌘-click imports (on by default per pack — issue #26)
-Hold ⌘ and hover an import → it underlines in the accent color with a pointer cursor;
-⌘-click opens the target file. ON by default for every installed pack that supports it
-(Rust, TypeScript/TSX, JavaScript, Python), per-pack opt-OUT via the "⌘-click imports"
-checkbox on the pack's row (persisted as `links_disabled` in plugins.json,
-`Plugins::links_on/set_links` — same model as error highlighting). Pipeline:
-`kyde_syntax::import_links(source, lang)` (pure — Rust `mod x;`/`use` paths incl.
-wildcards + `as`, TS/JS `import`/`export from`/`require()`/dynamic `import()`, Python
-`import a.b`/`from .rel import c`; perf guard `perf_import_links_large_file_stays_fast`)
-→ cached on `CodeEditor.import_links`, recomputed with `spans` only when `links_on`
-(`set_link_navigation`, pushed by the app from `Kyde::links_enabled_for(lang)` at the
-same four sites as the error flag). The editor tracks ⌘ via `on_modifiers_changed`
-(`cmd_held`) and hover via `on_mouse_move` (`hover_link`); the hovered link underlines
-through `apply_underline_ranges` (the generalized run-splitter behind the error
-squiggles) and the div cursor flips to PointingHand. ⌘-click emits
-`EditorEvent::OpenImport(link)` → `Kyde::open_import_link` resolves it with
-`kyde_syntax::resolve_import` (pure: TS relative specifiers + extension/index
-candidates, Python dotted/relative → `x.py`/`__init__.py`, Rust `mod` → sibling and
-`crate::`/`super::`/`self::` → progressively-shorter `src/` paths; bare specifiers =
-external → `None`) against `browse.all_files` and opens the hit. Smoke test:
-`cmd_click_import_opens_the_target_file`. Debug shot: `KYDE_SHOT=imports`
-(`CodeEditor::force_link_hover` fakes the ⌘-hover).
+### ⌘-click navigation (on by default per pack — issue #26)
+Hold ⌘ and hover a NAVIGABLE thing → accent underline + pointer cursor; ⌘-click acts.
+Three targets (classified by `CodeEditor::symbol_at`, in priority order):
+1. **An import specifier** → opens the referenced file. `kyde_syntax::import_links`
+   (Rust `mod x;`/`use` paths incl. wildcards + `as`; TS/JS `import`/`export from`/
+   `require()`/dynamic `import()`; Python `import a.b`/`from .rel import c`) →
+   `EditorEvent::OpenImport` → `Kyde::open_import_link` → `kyde_syntax::resolve_import`
+   (pure: TS relative specifiers + extension/index candidates, Python dotted/relative →
+   `x.py`/`__init__.py`, Rust `mod` → sibling and `crate::`/`super::`/`self::` →
+   progressively-shorter `src/` paths; bare specifiers = external → `None`) against
+   `browse.all_files`.
+2. **A symbol defined in THIS buffer** (vars/types/fns — `kyde_syntax::definition_sites`:
+   Rust items + `let`/params/closures/for-patterns, TS/JS declarations + declarators/
+   params/methods/arrows, Python `def`/`class`/assignments/params/for) → the editor
+   jumps in place (`select_range`, reveals). Definitions shadow import bindings.
+3. **A use of an IMPORTED symbol** (`kyde_syntax::import_bindings` — Rust use
+   names/aliases/lists, TS default/named-`as`/namespace, Python module first-segments +
+   `from` names/aliases) → `EditorEvent::OpenSymbol{link,name}` →
+   `Kyde::open_import_symbol`: resolve the import's file, open it (new tab), find
+   `name` in ITS definition_sites, select it.
+ON by default for every installed pack that supports it (Rust, TS/TSX, JS, Python);
+per-pack opt-OUT via the "⌘-click imports" checkbox (persisted `links_disabled`,
+`Plugins::links_on/set_links` — the error-highlighting model). Editor caches
+(`import_links` + `import_bound` + `defs` = `compute_nav`) recompute with `spans` only
+when `links_on` (`set_link_navigation`, pushed from `Kyde::links_enabled_for` at the
+same four sites as the error flag); perf guards `perf_import_links_*` +
+`perf_definition_sites_*`. ⌘ state rides each mouse-move's OWN `modifiers` (a
+`ModifiersChanged` only reaches the editor via focus — unreliable on unfocused panes)
+AND `on_modifiers_changed` recomputes hover from `last_mouse`, so pressing ⌘ over a
+symbol lights it up without moving. Underline = `apply_underline_ranges` on
+`hover_range`. Smoke tests: `cmd_click_import_opens_the_target_file`,
+`cmd_click_symbol_jumps_to_its_definition`. Debug shot: `KYDE_SHOT=imports`
+(`force_link_hover`).
+
+### What "adding a language pack" MEANS (the per-language feature contract)
+A pack is not just colors. Wiring a new `Lang` into kyde-syntax involves up to FIVE
+per-language capabilities — implement what the grammar supports, and note the gaps:
+1. **Highlighting** (required): `config()` arm (grammar + highlight query + CAPTURES).
+2. **Folding** (free): `grammar()` arm — `fold_regions` works generically from it.
+3. **Error highlighting** (free): `error_ranges` works generically from `grammar()`.
+4. **⌘-click imports** (opt-in per lang): arms in `imports_with_bindings` (link + the
+   names it binds) + a `resolve_import` strategy for the language's module system +
+   the lang in `import_links`/`definition_sites`/`sort_object_keys` gate matches.
+5. **Definitions** (opt-in per lang): `definition_sites` arms for the language's
+   declaration forms (drives same-file jump + imported-symbol landing).
+Also: `Lang::from_path` extension mapping, `Lang::pack` id, `PACKS` entry behind the
+Cargo feature, `pack_ext`/`pack_size` in modals.rs, and tests for each capability
+added (the `every_lang_with_a_pack_actually_highlights` style). Langs 4+5 currently
+cover: Rust, TS/TSX, JS, Python. JSON additionally has `sort_object_keys` (with JS/TS).
 
 ### Two independent layers — Cargo features (build) vs install list (runtime)
 The plugin system is **two separate gates**, do not conflate them:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,6 +518,29 @@ CVD variants ride the conflict accent) — the squiggle paints inside the normal
 appear wherever the editor's flag is on (Browse; diff/merge panes never set it).
 Debug shot: `KYDE_SHOT=error-highlight` + `KYDE_SHOT_FILE=<invalid .json>`.
 
+### ⌘-click imports (on by default per pack — issue #26)
+Hold ⌘ and hover an import → it underlines in the accent color with a pointer cursor;
+⌘-click opens the target file. ON by default for every installed pack that supports it
+(Rust, TypeScript/TSX, JavaScript, Python), per-pack opt-OUT via the "⌘-click imports"
+checkbox on the pack's row (persisted as `links_disabled` in plugins.json,
+`Plugins::links_on/set_links` — same model as error highlighting). Pipeline:
+`kyde_syntax::import_links(source, lang)` (pure — Rust `mod x;`/`use` paths incl.
+wildcards + `as`, TS/JS `import`/`export from`/`require()`/dynamic `import()`, Python
+`import a.b`/`from .rel import c`; perf guard `perf_import_links_large_file_stays_fast`)
+→ cached on `CodeEditor.import_links`, recomputed with `spans` only when `links_on`
+(`set_link_navigation`, pushed by the app from `Kyde::links_enabled_for(lang)` at the
+same four sites as the error flag). The editor tracks ⌘ via `on_modifiers_changed`
+(`cmd_held`) and hover via `on_mouse_move` (`hover_link`); the hovered link underlines
+through `apply_underline_ranges` (the generalized run-splitter behind the error
+squiggles) and the div cursor flips to PointingHand. ⌘-click emits
+`EditorEvent::OpenImport(link)` → `Kyde::open_import_link` resolves it with
+`kyde_syntax::resolve_import` (pure: TS relative specifiers + extension/index
+candidates, Python dotted/relative → `x.py`/`__init__.py`, Rust `mod` → sibling and
+`crate::`/`super::`/`self::` → progressively-shorter `src/` paths; bare specifiers =
+external → `None`) against `browse.all_files` and opens the hit. Smoke test:
+`cmd_click_import_opens_the_target_file`. Debug shot: `KYDE_SHOT=imports`
+(`CodeEditor::force_link_hover` fakes the ⌘-hover).
+
 ### Two independent layers — Cargo features (build) vs install list (runtime)
 The plugin system is **two separate gates**, do not conflate them:
 - **Cargo features** (`Cargo.toml [features]`, one per pack: `rust`, `typescript`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -538,6 +538,14 @@ Three targets (classified by `CodeEditor::symbol_at`, in priority order):
    `from` names/aliases) → `EditorEvent::OpenSymbol{link,name}` →
    `Kyde::open_import_symbol`: resolve the import's file, open it (new tab), find
    `name` in ITS definition_sites, select it.
+4. **METHODS/symbols defined in imported files** (`obj.method()` where the class came
+   from an import): `Kyde::refresh_external_defs` resolves every import target and
+   indexes those files' `definition_sites` in the BACKGROUND (name → path+range,
+   pushed via `CodeEditor::set_external_defs`; recomputed only when the buffer's
+   import TARGET SET changes — `import_targets()` comparison — and generation-guarded
+   against stale results; cleared by `set_content`). Lowest lookup priority; click →
+   `EditorEvent::OpenDefinition{path,range}` → `Kyde::open_definition_at`. No type
+   inference — a name defined in several imported files resolves to the first.
 ON by default for every installed pack that supports it (Rust, TS/TSX, JS, Python);
 per-pack opt-OUT via the "⌘-click imports" checkbox (persisted `links_disabled`,
 `Plugins::links_on/set_links` — the error-highlighting model). Editor caches

--- a/crates/kyde-config/src/plugins.rs
+++ b/crates/kyde-config/src/plugins.rs
@@ -20,6 +20,10 @@ pub struct Plugins {
     /// so an empty set (and any pre-existing plugins.json) means all on.
     #[serde(default)]
     errors_disabled: BTreeSet<String>,
+    /// Pack ids with ⌘-click import navigation opted OUT — same default-on,
+    /// per-pack opt-out model as `errors_disabled`.
+    #[serde(default)]
+    links_disabled: BTreeSet<String>,
 }
 
 impl Plugins {
@@ -35,10 +39,27 @@ impl Plugins {
 
     /// Remove a pack from the installed set (its grammar is still compiled in, but the
     /// editor falls back to `PlainText` for that language until re-installed).
-    /// Also drops the pack's error-highlighting opt-out (reinstall = fresh defaults).
+    /// Also drops the pack's per-feature opt-outs (reinstall = fresh defaults).
     pub fn uninstall(&mut self, pack_id: &str) {
         self.installed.remove(pack_id);
         self.errors_disabled.remove(pack_id);
+        self.links_disabled.remove(pack_id);
+    }
+
+    /// Whether ⌘-click import navigation is on for `pack_id` — the default
+    /// unless the user opted out. Callers gate on `is_installed` first.
+    pub fn links_on(&self, pack_id: &str) -> bool {
+        !self.links_disabled.contains(pack_id)
+    }
+
+    /// Turn ⌘-click import navigation on/off for `pack_id` (default on; `false`
+    /// records a per-pack opt-out).
+    pub fn set_links(&mut self, pack_id: &str, on: bool) {
+        if on {
+            self.links_disabled.remove(pack_id);
+        } else {
+            self.links_disabled.insert(pack_id.to_string());
+        }
     }
 
     /// Whether error highlighting is on for `pack_id` — the default unless the
@@ -119,5 +140,22 @@ mod tests {
         q.uninstall("json");
         q.install("json");
         assert!(q.errors_on("json"), "reinstall must return to default-on");
+    }
+
+    #[test]
+    fn links_default_on_and_opt_out_round_trips() {
+        let mut p = Plugins::default();
+        p.install("rust");
+        assert!(p.links_on("rust"), "cmd-click imports must default ON");
+        p.set_links("rust", false);
+        assert!(!p.links_on("rust"));
+        let back: Plugins = serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
+        assert!(!back.links_on("rust"));
+        // Old plugins.json without the field → on; uninstall drops the opt-out.
+        let old: Plugins = serde_json::from_str(r#"{"installed":["rust"]}"#).unwrap();
+        assert!(old.links_on("rust"));
+        p.uninstall("rust");
+        p.install("rust");
+        assert!(p.links_on("rust"));
     }
 }

--- a/crates/kyde-syntax/src/lib.rs
+++ b/crates/kyde-syntax/src/lib.rs
@@ -862,6 +862,28 @@ pub struct ImportLink {
 /// assert!(import_links("hello\n", Lang::PlainText).is_empty());
 /// ```
 pub fn import_links(source: &str, lang: Lang) -> Vec<ImportLink> {
+    imports_with_bindings(source, lang)
+        .into_iter()
+        .map(|(l, _)| l)
+        .collect()
+}
+
+/// The local names each import binds, paired with that import's [`ImportLink`]
+/// — so ⌘-clicking a USE of an imported symbol can jump through to the file it
+/// came from. Rust `use` names/aliases/lists, TS/JS default + named (incl.
+/// `as`) + namespace imports, Python module first-segments and `from`-names.
+/// Wildcards bind nothing knowable and are skipped.
+#[must_use]
+pub fn import_bindings(source: &str, lang: Lang) -> Vec<(String, ImportLink)> {
+    imports_with_bindings(source, lang)
+        .into_iter()
+        .flat_map(|(l, names)| names.into_iter().map(move |n| (n, l.clone())))
+        .collect()
+}
+
+/// Shared walk behind [`import_links`] / [`import_bindings`]: every import in
+/// `source` as `(link, names it binds locally)`, sorted by position.
+fn imports_with_bindings(source: &str, lang: Lang) -> Vec<(ImportLink, Vec<String>)> {
     if !matches!(
         lang,
         Lang::Rust | Lang::Ts | Lang::Tsx | Lang::Js | Lang::Python
@@ -878,26 +900,56 @@ pub fn import_links(source: &str, lang: Lang) -> Vec<ImportLink> {
     let Some(tree) = parser.parse(source, None) else {
         return Vec::new();
     };
-    let mut out = Vec::new();
+    let mut out: Vec<(ImportLink, Vec<String>)> = Vec::new();
     let text = |n: tree_sitter::Node| source.get(n.byte_range()).unwrap_or("").to_string();
-    let push = |out: &mut Vec<ImportLink>, n: tree_sitter::Node, kind: ImportKind, src: &str| {
-        let target = src.get(n.byte_range()).unwrap_or("").to_string();
-        if !target.is_empty() {
-            out.push(ImportLink {
-                range: n.byte_range(),
-                target,
-                kind,
-            });
-        }
+    let link = |n: tree_sitter::Node, kind: ImportKind| -> Option<ImportLink> {
+        let target = source.get(n.byte_range()).unwrap_or("").to_string();
+        (!target.is_empty()).then_some(ImportLink {
+            range: n.byte_range(),
+            target,
+            kind,
+        })
     };
+    // The names a Rust use-tree binds: plain/scoped idents bind their last
+    // segment, `as` clauses their alias, `{…}` lists each entry (recursively);
+    // wildcards bind nothing knowable.
+    fn rust_use_names(n: tree_sitter::Node, src: &str, out: &mut Vec<String>) {
+        let txt = |m: tree_sitter::Node| src.get(m.byte_range()).unwrap_or("").to_string();
+        match n.kind() {
+            "identifier" => out.push(txt(n)),
+            "scoped_identifier" => {
+                if let Some(name) = n.child_by_field_name("name") {
+                    out.push(txt(name));
+                }
+            }
+            "use_as_clause" => {
+                if let Some(a) = n.child_by_field_name("alias") {
+                    out.push(txt(a));
+                }
+            }
+            "scoped_use_list" | "use_list" => {
+                let list = n.child_by_field_name("list").unwrap_or(n);
+                for i in 0..list.named_child_count() {
+                    if let Some(c) = list.named_child(i) {
+                        rust_use_names(c, src, out);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
     let mut stack = vec![tree.root_node()];
     while let Some(node) = stack.pop() {
         match (lang, node.kind()) {
-            // Rust: `mod name;` with no inline body → sibling file module.
+            // Rust: `mod name;` with no inline body → sibling file module. Binds
+            // the module name (`widgets::x` paths then resolve via the mod file).
             (Lang::Rust, "mod_item") => {
                 if node.child_by_field_name("body").is_none() {
                     if let Some(name) = node.child_by_field_name("name") {
-                        push(&mut out, name, ImportKind::RustMod, source);
+                        if let Some(l) = link(name, ImportKind::RustMod) {
+                            let names = vec![text(name)];
+                            out.push((l, names));
+                        }
                     }
                 }
             }
@@ -914,17 +966,52 @@ pub fn import_links(source: &str, lang: Lang) -> Vec<ImportLink> {
                         _ => None,
                     };
                     if let Some(p) = path {
-                        push(&mut out, p, ImportKind::RustUse, source);
+                        if let Some(l) = link(p, ImportKind::RustUse) {
+                            let mut names = Vec::new();
+                            rust_use_names(arg, source, &mut names);
+                            out.push((l, names));
+                        }
                     }
                 }
             }
-            // TS/TSX/JS: `import … from "x"` / `export … from "x"`.
+            // TS/TSX/JS: `import … from "x"` / `export … from "x"`. Only the
+            // import form binds local names (default / named / namespace).
             (Lang::Ts | Lang::Tsx | Lang::Js, "import_statement" | "export_statement") => {
                 if let Some(s) = node.child_by_field_name("source") {
-                    push(&mut out, string_body(s), ImportKind::Specifier, source);
+                    if let Some(l) = link(string_body(s), ImportKind::Specifier) {
+                        let mut names = Vec::new();
+                        if node.kind() == "import_statement" {
+                            let mut st = vec![node];
+                            while let Some(n) = st.pop() {
+                                match n.kind() {
+                                    // Default import + namespace ident both land here.
+                                    "identifier" => names.push(text(n)),
+                                    "import_specifier" => {
+                                        if let Some(b) = n
+                                            .child_by_field_name("alias")
+                                            .or_else(|| n.child_by_field_name("name"))
+                                        {
+                                            names.push(text(b));
+                                        }
+                                        continue;
+                                    }
+                                    "string" => continue, // the source — not a binding
+                                    _ => {}
+                                }
+                                for i in 0..n.named_child_count() {
+                                    if let Some(c) = n.named_child(i) {
+                                        st.push(c);
+                                    }
+                                }
+                            }
+                        }
+                        out.push((l, names));
+                    }
                 }
             }
-            // TS/TSX/JS: `require("x")` and dynamic `import("x")`.
+            // TS/TSX/JS: `require("x")` and dynamic `import("x")`. The binding
+            // (if any) is an ordinary variable declarator — a local definition —
+            // so the import itself binds nothing here.
             (Lang::Ts | Lang::Tsx | Lang::Js, "call_expression") => {
                 let is_import_call = node.child_by_field_name("function").is_some_and(|f| {
                     f.kind() == "import" || (f.kind() == "identifier" && text(f) == "require")
@@ -935,30 +1022,60 @@ pub fn import_links(source: &str, lang: Lang) -> Vec<ImportLink> {
                         .and_then(|a| a.named_child(0))
                         .filter(|a| a.kind() == "string")
                     {
-                        push(&mut out, string_body(s), ImportKind::Specifier, source);
+                        if let Some(l) = link(string_body(s), ImportKind::Specifier) {
+                            out.push((l, Vec::new()));
+                        }
                     }
                 }
             }
-            // Python: `import a.b, c` — each dotted/aliased name.
+            // Python: `import a.b, c` — each dotted/aliased name. `import a.b`
+            // binds `a` (the first segment); an alias binds the alias.
             (Lang::Python, "import_statement") => {
                 for i in 0..node.named_child_count() {
                     let Some(c) = node.named_child(i) else {
                         continue;
                     };
-                    let name = match c.kind() {
-                        "dotted_name" => Some(c),
-                        "aliased_import" => c.child_by_field_name("name"),
-                        _ => None,
+                    let (name, bound) = match c.kind() {
+                        "dotted_name" => {
+                            let first = c.named_child(0).map(text);
+                            (Some(c), first)
+                        }
+                        "aliased_import" => (
+                            c.child_by_field_name("name"),
+                            c.child_by_field_name("alias").map(text),
+                        ),
+                        _ => (None, None),
                     };
                     if let Some(n) = name {
-                        push(&mut out, n, ImportKind::Specifier, source);
+                        if let Some(l) = link(n, ImportKind::Specifier) {
+                            out.push((l, bound.into_iter().collect()));
+                        }
                     }
                 }
             }
-            // Python: `from a.b import c` / `from .rel import d`.
+            // Python: `from a.b import c as d, e` — binds d + e against the module.
             (Lang::Python, "import_from_statement") => {
                 if let Some(m) = node.child_by_field_name("module_name") {
-                    push(&mut out, m, ImportKind::Specifier, source);
+                    if let Some(l) = link(m, ImportKind::Specifier) {
+                        let mut names = Vec::new();
+                        let mut w = node.walk();
+                        for c in node.children_by_field_name("name", &mut w) {
+                            match c.kind() {
+                                "dotted_name" => {
+                                    if let Some(f) = c.named_child(0) {
+                                        names.push(text(f));
+                                    }
+                                }
+                                "aliased_import" => {
+                                    if let Some(a) = c.child_by_field_name("alias") {
+                                        names.push(text(a));
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        out.push((l, names));
+                    }
                 }
             }
             _ => {}
@@ -969,7 +1086,139 @@ pub fn import_links(source: &str, lang: Lang) -> Vec<ImportLink> {
             }
         }
     }
-    out.sort_by_key(|l| l.range.start);
+    out.sort_by_key(|(l, _)| l.range.start);
+    out
+}
+
+/// Definition sites in `source` as `(name, byte range of the name)`, sorted by
+/// position — the go-to-definition index behind ⌘-clicking a variable/type.
+/// Covers the declaration forms of the supported languages (Rust items +
+/// `let`/params, TS/JS declarations + declarators/params/methods, Python
+/// `def`/`class`/assignments/params); other languages return no sites.
+///
+/// ```
+/// use kyde_syntax::{definition_sites, Lang};
+/// let sites = definition_sites("const foo = 1;\n", Lang::Ts);
+/// assert_eq!(sites.len(), 1);
+/// assert_eq!(sites[0].0, "foo");
+/// ```
+#[must_use]
+pub fn definition_sites(source: &str, lang: Lang) -> Vec<(String, std::ops::Range<usize>)> {
+    if !matches!(
+        lang,
+        Lang::Rust | Lang::Ts | Lang::Tsx | Lang::Js | Lang::Python
+    ) {
+        return Vec::new();
+    }
+    let Some(grammar) = lang.grammar() else {
+        return Vec::new();
+    };
+    let mut parser = tree_sitter::Parser::new();
+    if parser.set_language(&grammar).is_err() {
+        return Vec::new();
+    }
+    let Some(tree) = parser.parse(source, None) else {
+        return Vec::new();
+    };
+    let mut out: Vec<(String, std::ops::Range<usize>)> = Vec::new();
+    let push = |out: &mut Vec<(String, std::ops::Range<usize>)>, n: tree_sitter::Node| {
+        if let Some(t) = source.get(n.byte_range()) {
+            if !t.is_empty() {
+                out.push((t.to_string(), n.byte_range()));
+            }
+        }
+    };
+    // Collect the bound identifiers inside a (possibly destructuring) pattern.
+    // Property KEYS are `property_identifier`/`field_identifier` nodes, not
+    // `identifier`, so walking for identifiers never picks up map keys.
+    let bind_pattern = |out: &mut Vec<(String, std::ops::Range<usize>)>, p: tree_sitter::Node| {
+        let mut st = vec![p];
+        while let Some(n) = st.pop() {
+            match n.kind() {
+                "identifier" | "shorthand_property_identifier_pattern" => push(out, n),
+                _ => {
+                    for i in 0..n.named_child_count() {
+                        if let Some(c) = n.named_child(i) {
+                            st.push(c);
+                        }
+                    }
+                }
+            }
+        }
+    };
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        match (lang, node.kind()) {
+            // Rust items — the `name` field is the definition site.
+            (
+                Lang::Rust,
+                "function_item" | "struct_item" | "enum_item" | "union_item" | "trait_item"
+                | "type_item" | "const_item" | "static_item" | "mod_item" | "macro_definition",
+            )
+            | (
+                Lang::Ts | Lang::Tsx | Lang::Js,
+                "function_declaration"
+                | "generator_function_declaration"
+                | "class_declaration"
+                | "abstract_class_declaration"
+                | "interface_declaration"
+                | "type_alias_declaration"
+                | "enum_declaration"
+                | "method_definition",
+            )
+            | (Lang::Python, "function_definition" | "class_definition") => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    push(&mut out, name);
+                }
+            }
+            // Rust `let` bindings + parameters (incl. destructuring patterns).
+            (Lang::Rust, "let_declaration" | "parameter" | "for_expression") => {
+                if let Some(p) = node.child_by_field_name("pattern") {
+                    bind_pattern(&mut out, p);
+                }
+            }
+            (Lang::Rust, "closure_parameters") => bind_pattern(&mut out, node),
+            // TS/JS `const`/`let`/`var` declarators + parameters.
+            (Lang::Ts | Lang::Tsx | Lang::Js, "variable_declarator") => {
+                if let Some(n) = node.child_by_field_name("name") {
+                    bind_pattern(&mut out, n);
+                }
+            }
+            (Lang::Ts | Lang::Tsx | Lang::Js, "required_parameter" | "optional_parameter") => {
+                if let Some(p) = node.child_by_field_name("pattern") {
+                    bind_pattern(&mut out, p);
+                }
+            }
+            // `x => …` — the bare arrow parameter is a plain identifier.
+            (Lang::Ts | Lang::Tsx | Lang::Js, "arrow_function") => {
+                if let Some(p) = node
+                    .child_by_field_name("parameter")
+                    .filter(|p| p.kind() == "identifier")
+                {
+                    push(&mut out, p);
+                }
+            }
+            // Python assignments, parameters, and `for` targets.
+            (Lang::Python, "assignment") => {
+                if let Some(l) = node.child_by_field_name("left") {
+                    bind_pattern(&mut out, l);
+                }
+            }
+            (Lang::Python, "parameters") => bind_pattern(&mut out, node),
+            (Lang::Python, "for_statement") => {
+                if let Some(l) = node.child_by_field_name("left") {
+                    bind_pattern(&mut out, l);
+                }
+            }
+            _ => {}
+        }
+        for i in 0..node.child_count() {
+            if let Some(c) = node.child(i) {
+                stack.push(c);
+            }
+        }
+    }
+    out.sort_by_key(|(_, r)| r.start);
     out
 }
 
@@ -1587,6 +1836,107 @@ mod tests {
             resolve_import(&links[4], Lang::Rust, &cur, &files),
             Some(pb("src/util/mod.rs")),
             "use list prefix → module dir"
+        );
+    }
+
+    #[test]
+    fn definition_sites_cover_declaration_forms() {
+        // Rust: items, let patterns, params.
+        let rs = "fn hello(count: i32) {\n    let (a, b) = (1, 2);\n}\nstruct Thing;\nconst MAX: u32 = 9;\n";
+        let sites = definition_sites(rs, Lang::Rust);
+        let names: Vec<&str> = sites.iter().map(|(n, _)| n.as_str()).collect();
+        for want in ["hello", "count", "a", "b", "Thing", "MAX"] {
+            assert!(names.contains(&want), "Rust missing {want}: {names:?}");
+        }
+        // Ranges point at the NAME text.
+        for (n, r) in definition_sites(rs, Lang::Rust) {
+            assert_eq!(&rs[r], n);
+        }
+        // Python: def/class/assignment/params/for.
+        let py = "class Cat:\n    def meow(self, times):\n        volume = times\n";
+        let names: Vec<String> = definition_sites(py, Lang::Python)
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect();
+        for want in ["Cat", "meow", "self", "times", "volume"] {
+            assert!(names.iter().any(|n| n == want), "Py missing {want}");
+        }
+        // Unsupported langs → empty.
+        assert!(definition_sites("a = 1", Lang::Yaml).is_empty());
+    }
+
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn definition_sites_ts_declarators_params_methods() {
+        let ts = "const { a, b: renamed } = obj;\nfunction go(x: number) {}\nclass K { run() {} }\nconst f = (y) => y;\ntype Alias = string;\n";
+        let names: Vec<String> = definition_sites(ts, Lang::Ts)
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect();
+        for want in ["a", "renamed", "go", "x", "K", "run", "f", "y", "Alias"] {
+            assert!(
+                names.iter().any(|n| n == want),
+                "TS missing {want}: {names:?}"
+            );
+        }
+        // Destructuring KEYS are not definitions (only bound values).
+        assert!(!names.iter().any(|n| n == "b"), "key `b` must not bind");
+    }
+
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn import_bindings_map_names_to_their_links() {
+        let ts = "import Def, { a, b as c } from './x';\nimport * as ns from './y';\n";
+        let binds = import_bindings(ts, Lang::Ts);
+        let names: Vec<&str> = binds.iter().map(|(n, _)| n.as_str()).collect();
+        for want in ["Def", "a", "c", "ns"] {
+            assert!(
+                names.contains(&want),
+                "TS binding missing {want}: {names:?}"
+            );
+        }
+        assert!(!names.contains(&"b"), "`b as c` binds c, not b");
+        assert!(binds
+            .iter()
+            .all(|(n, l)| { (l.target == "./x") == ["Def", "a", "c"].contains(&n.as_str()) }));
+
+        let rs = "use crate::views::browse;\nuse crate::util::{a, b as c};\nmod widgets;\n";
+        let binds = import_bindings(rs, Lang::Rust);
+        let names: Vec<&str> = binds.iter().map(|(n, _)| n.as_str()).collect();
+        for want in ["browse", "a", "c", "widgets"] {
+            assert!(
+                names.contains(&want),
+                "Rust binding missing {want}: {names:?}"
+            );
+        }
+
+        let py = "import os.path\nfrom pkg.mod import thing as t, other\n";
+        let binds = import_bindings(py, Lang::Python);
+        let names: Vec<&str> = binds.iter().map(|(n, _)| n.as_str()).collect();
+        for want in ["os", "t", "other"] {
+            assert!(
+                names.contains(&want),
+                "Py binding missing {want}: {names:?}"
+            );
+        }
+    }
+
+    /// Performance regression guard — see CLAUDE.md "Performance regression tests".
+    /// `definition_sites` + `import_bindings` recompute per keystroke alongside
+    /// `import_links` when a pack's ⌘-click navigation is on.
+    #[test]
+    fn perf_definition_sites_large_file_stays_fast() {
+        let unit =
+            "fn f(x: i32) -> i32 {\n    let y = x + 1;\n    y * 2\n}\nuse crate::views::browse;\n";
+        let src = unit.repeat(1200); // ~6000 lines
+        let start = std::time::Instant::now();
+        let defs = definition_sites(&src, Lang::Rust);
+        let binds = import_bindings(&src, Lang::Rust);
+        let elapsed = start.elapsed();
+        assert!(!defs.is_empty() && !binds.is_empty());
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "definition_sites+bindings on ~6000 lines took {elapsed:?} (budget 2s)"
         );
     }
 

--- a/crates/kyde-syntax/src/lib.rs
+++ b/crates/kyde-syntax/src/lib.rs
@@ -823,6 +823,296 @@ pub fn sort_object_keys(
     Some((range, text))
 }
 
+// ── import links (cmd+click to open — issue #26) ───────────────────
+
+/// What kind of import an [`ImportLink`] came from — drives resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportKind {
+    /// A module specifier: a quoted path in TS/JS (`import x from "./y"`) or a
+    /// dotted module path in Python (`import a.b`, `from .rel import c`).
+    Specifier,
+    /// Rust `mod name;` (no body) — the module lives in a sibling file.
+    RustMod,
+    /// A Rust `use` path — resolved from the crate's `src/` root (best effort).
+    RustUse,
+}
+
+/// One clickable import reference in a buffer.
+#[derive(Debug, Clone)]
+pub struct ImportLink {
+    /// Byte range to underline (the specifier/path text, quotes excluded).
+    pub range: std::ops::Range<usize>,
+    /// The raw specifier text (used by [`resolve_import`]).
+    pub target: String,
+    /// Which import form produced it.
+    pub kind: ImportKind,
+}
+
+/// Extract the import references of `source` for cmd+click navigation.
+/// Supported: Rust (`mod x;` without a body, `use` paths), TypeScript/TSX/
+/// JavaScript (`import`/`export … from "x"`, `require("x")`, dynamic
+/// `import("x")`), and Python (`import a.b`, `from .rel import c`). Other
+/// languages (or a feature-trimmed build) return no links.
+///
+/// ```
+/// use kyde_syntax::{import_links, Lang};
+/// let links = import_links("import { a } from './x';\n", Lang::Ts);
+/// assert_eq!(links.len(), 1);
+/// assert_eq!(links[0].target, "./x");
+/// assert!(import_links("hello\n", Lang::PlainText).is_empty());
+/// ```
+pub fn import_links(source: &str, lang: Lang) -> Vec<ImportLink> {
+    if !matches!(
+        lang,
+        Lang::Rust | Lang::Ts | Lang::Tsx | Lang::Js | Lang::Python
+    ) {
+        return Vec::new();
+    }
+    let Some(grammar) = lang.grammar() else {
+        return Vec::new();
+    };
+    let mut parser = tree_sitter::Parser::new();
+    if parser.set_language(&grammar).is_err() {
+        return Vec::new();
+    }
+    let Some(tree) = parser.parse(source, None) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let text = |n: tree_sitter::Node| source.get(n.byte_range()).unwrap_or("").to_string();
+    let push = |out: &mut Vec<ImportLink>, n: tree_sitter::Node, kind: ImportKind, src: &str| {
+        let target = src.get(n.byte_range()).unwrap_or("").to_string();
+        if !target.is_empty() {
+            out.push(ImportLink {
+                range: n.byte_range(),
+                target,
+                kind,
+            });
+        }
+    };
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        match (lang, node.kind()) {
+            // Rust: `mod name;` with no inline body → sibling file module.
+            (Lang::Rust, "mod_item") => {
+                if node.child_by_field_name("body").is_none() {
+                    if let Some(name) = node.child_by_field_name("name") {
+                        push(&mut out, name, ImportKind::RustMod, source);
+                    }
+                }
+            }
+            // Rust: the `use` path — for `use a::b::{c, d}` link the `a::b` prefix.
+            (Lang::Rust, "use_declaration") => {
+                if let Some(arg) = node.child_by_field_name("argument") {
+                    let path = match arg.kind() {
+                        "scoped_use_list" | "use_as_clause" => arg.child_by_field_name("path"),
+                        // `use path::*` — the wildcard wraps its path as the first child.
+                        "use_wildcard" => arg.named_child(0),
+                        "scoped_identifier" | "identifier" | "crate" | "super" | "self" => {
+                            Some(arg)
+                        }
+                        _ => None,
+                    };
+                    if let Some(p) = path {
+                        push(&mut out, p, ImportKind::RustUse, source);
+                    }
+                }
+            }
+            // TS/TSX/JS: `import … from "x"` / `export … from "x"`.
+            (Lang::Ts | Lang::Tsx | Lang::Js, "import_statement" | "export_statement") => {
+                if let Some(s) = node.child_by_field_name("source") {
+                    push(&mut out, string_body(s), ImportKind::Specifier, source);
+                }
+            }
+            // TS/TSX/JS: `require("x")` and dynamic `import("x")`.
+            (Lang::Ts | Lang::Tsx | Lang::Js, "call_expression") => {
+                let is_import_call = node.child_by_field_name("function").is_some_and(|f| {
+                    f.kind() == "import" || (f.kind() == "identifier" && text(f) == "require")
+                });
+                if is_import_call {
+                    if let Some(s) = node
+                        .child_by_field_name("arguments")
+                        .and_then(|a| a.named_child(0))
+                        .filter(|a| a.kind() == "string")
+                    {
+                        push(&mut out, string_body(s), ImportKind::Specifier, source);
+                    }
+                }
+            }
+            // Python: `import a.b, c` — each dotted/aliased name.
+            (Lang::Python, "import_statement") => {
+                for i in 0..node.named_child_count() {
+                    let Some(c) = node.named_child(i) else {
+                        continue;
+                    };
+                    let name = match c.kind() {
+                        "dotted_name" => Some(c),
+                        "aliased_import" => c.child_by_field_name("name"),
+                        _ => None,
+                    };
+                    if let Some(n) = name {
+                        push(&mut out, n, ImportKind::Specifier, source);
+                    }
+                }
+            }
+            // Python: `from a.b import c` / `from .rel import d`.
+            (Lang::Python, "import_from_statement") => {
+                if let Some(m) = node.child_by_field_name("module_name") {
+                    push(&mut out, m, ImportKind::Specifier, source);
+                }
+            }
+            _ => {}
+        }
+        for i in 0..node.child_count() {
+            if let Some(c) = node.child(i) {
+                stack.push(c);
+            }
+        }
+    }
+    out.sort_by_key(|l| l.range.start);
+    out
+}
+
+/// The unquoted body of a TS/JS `string` node (its `string_fragment` child), so
+/// the link range excludes the quote characters. An empty string (`""`) has no
+/// fragment — the node itself comes back and produces an empty, dropped target.
+fn string_body(s: tree_sitter::Node) -> tree_sitter::Node {
+    for i in 0..s.named_child_count() {
+        if let Some(c) = s.named_child(i) {
+            if c.kind() == "string_fragment" {
+                return c;
+            }
+        }
+    }
+    s
+}
+
+/// Resolve an [`ImportLink`] to a project file, best effort. `current` is the
+/// file being edited and `files` the project's (repo-relative) file list; both
+/// use the same relative paths the Browse tree serves. Returns `None` for
+/// external modules (npm packages, crates.io deps, python stdlib) and anything
+/// that doesn't land on a listed file.
+#[must_use]
+pub fn resolve_import(
+    link: &ImportLink,
+    lang: Lang,
+    current: &Path,
+    files: &[std::path::PathBuf],
+) -> Option<std::path::PathBuf> {
+    let exists = |p: &std::path::PathBuf| files.iter().any(|f| f == p);
+    let dir = current.parent().unwrap_or_else(|| Path::new(""));
+    // Join + normalize `.`/`..` without touching the filesystem.
+    let norm = |base: &Path, rel: &str| -> std::path::PathBuf {
+        let mut out: Vec<std::ffi::OsString> = base
+            .components()
+            .map(|c| c.as_os_str().to_os_string())
+            .collect();
+        for seg in rel.split('/') {
+            match seg {
+                "" | "." => {}
+                ".." => {
+                    out.pop();
+                }
+                s => out.push(s.into()),
+            }
+        }
+        out.iter().collect()
+    };
+    let first = |cands: Vec<std::path::PathBuf>| cands.into_iter().find(exists);
+    match (lang, link.kind) {
+        // TS/JS: relative specifiers only (a bare specifier is a package).
+        (Lang::Ts | Lang::Tsx | Lang::Js, ImportKind::Specifier) => {
+            if !link.target.starts_with('.') {
+                return None;
+            }
+            let base = norm(dir, &link.target);
+            let mut cands = vec![base.clone()];
+            for ext in ["ts", "tsx", "js", "jsx", "mjs", "cjs", "d.ts"] {
+                cands.push(std::path::PathBuf::from(format!(
+                    "{}.{ext}",
+                    base.to_string_lossy()
+                )));
+            }
+            for idx in ["index.ts", "index.tsx", "index.js", "index.jsx"] {
+                cands.push(base.join(idx));
+            }
+            first(cands)
+        }
+        // Python: leading dots walk up from the current file's package.
+        (Lang::Python, ImportKind::Specifier) => {
+            let dots = link.target.chars().take_while(|&c| c == '.').count();
+            let rest = link.target[dots..].replace('.', "/");
+            let mut cands = Vec::new();
+            if dots > 0 {
+                let mut base = dir.to_path_buf();
+                for _ in 1..dots {
+                    base = base.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+                }
+                let p = if rest.is_empty() {
+                    base
+                } else {
+                    norm(&base, &rest)
+                };
+                cands.push(std::path::PathBuf::from(format!(
+                    "{}.py",
+                    p.to_string_lossy()
+                )));
+                cands.push(p.join("__init__.py"));
+            } else {
+                // Absolute module: try the project root, then the current dir.
+                for base in [Path::new(""), dir] {
+                    let p = norm(base, &rest);
+                    cands.push(std::path::PathBuf::from(format!(
+                        "{}.py",
+                        p.to_string_lossy()
+                    )));
+                    cands.push(p.join("__init__.py"));
+                }
+            }
+            first(cands)
+        }
+        // Rust `mod name;`: a sibling `name.rs` or `name/mod.rs`.
+        (Lang::Rust, ImportKind::RustMod) => first(vec![
+            dir.join(format!("{}.rs", link.target)),
+            dir.join(&link.target).join("mod.rs"),
+        ]),
+        // Rust `use` path: crate:: from src/, super:: from the parent module,
+        // self:: from here; progressively shorter suffixes since the last
+        // segments are usually items, not modules.
+        (Lang::Rust, ImportKind::RustUse) => {
+            let mut segs: Vec<&str> = link.target.split("::").collect();
+            let base = match segs.first().copied() {
+                Some("crate") => {
+                    segs.remove(0);
+                    std::path::PathBuf::from("src")
+                }
+                Some("super") => {
+                    segs.remove(0);
+                    dir.parent().unwrap_or_else(|| Path::new("")).to_path_buf()
+                }
+                Some("self") => {
+                    segs.remove(0);
+                    dir.to_path_buf()
+                }
+                // A plain first segment is almost always an external crate.
+                _ => return None,
+            };
+            let mut cands = Vec::new();
+            while !segs.is_empty() {
+                let joined: std::path::PathBuf = base.join(segs.join("/"));
+                cands.push(std::path::PathBuf::from(format!(
+                    "{}.rs",
+                    joined.to_string_lossy()
+                )));
+                cands.push(joined.join("mod.rs"));
+                segs.pop();
+            }
+            first(cands)
+        }
+        _ => None,
+    }
+}
+
 /// Iterate `(byte_start, line)` over `source`, tracking byte offsets including '\n'.
 fn lines_with_offsets(source: &str) -> impl Iterator<Item = (usize, &str)> {
     let mut off = 0usize;
@@ -1179,6 +1469,150 @@ mod tests {
         let src = "const x: T = { beta: 2, alpha: 1 };";
         let (_, out) = sort_object_keys(src, Lang::Ts, 16..16).unwrap();
         assert_eq!(out, "{ alpha: 1, beta: 2 }");
+    }
+
+    fn pb(s: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(s)
+    }
+
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn import_links_ts_forms_and_resolution() {
+        let src = "import { a } from './x';\nexport { b } from '../y';\nconst c = require('./w');\nimport('./lazy');\nimport npm from 'react';\n";
+        let links = import_links(src, Lang::Ts);
+        let targets: Vec<&str> = links.iter().map(|l| l.target.as_str()).collect();
+        assert_eq!(targets, ["./x", "../y", "./w", "./lazy", "react"]);
+        // Ranges exclude the quotes.
+        for l in &links {
+            assert_eq!(&src[l.range.clone()], l.target);
+        }
+        let files = [pb("app/x.ts"), pb("y/index.tsx"), pb("app/w/index.js")];
+        let cur = pb("app/main.ts");
+        assert_eq!(
+            resolve_import(&links[0], Lang::Ts, &cur, &files),
+            Some(pb("app/x.ts"))
+        );
+        assert_eq!(
+            resolve_import(&links[1], Lang::Ts, &cur, &files),
+            Some(pb("y/index.tsx")),
+            "../y → index file"
+        );
+        assert_eq!(
+            resolve_import(&links[2], Lang::Ts, &cur, &files),
+            Some(pb("app/w/index.js"))
+        );
+        assert_eq!(
+            resolve_import(&links[4], Lang::Ts, &cur, &files),
+            None,
+            "bare specifier = npm package"
+        );
+    }
+
+    #[cfg(feature = "python")]
+    #[test]
+    fn import_links_python_forms_and_resolution() {
+        let src = "import os\nimport pkg.mod\nfrom .sibling import x\nfrom ..up import y\n";
+        let links = import_links(src, Lang::Python);
+        let targets: Vec<&str> = links.iter().map(|l| l.target.as_str()).collect();
+        assert_eq!(targets, ["os", "pkg.mod", ".sibling", "..up"]);
+        let files = [
+            pb("pkg/mod.py"),
+            pb("pkg/sub/sibling.py"),
+            pb("pkg/up/__init__.py"),
+        ];
+        let cur = pb("pkg/sub/main.py");
+        assert_eq!(resolve_import(&links[0], Lang::Python, &cur, &files), None);
+        assert_eq!(
+            resolve_import(&links[1], Lang::Python, &cur, &files),
+            Some(pb("pkg/mod.py")),
+            "absolute module from the project root"
+        );
+        assert_eq!(
+            resolve_import(&links[2], Lang::Python, &cur, &files),
+            Some(pb("pkg/sub/sibling.py")),
+            ". = the current package"
+        );
+        assert_eq!(
+            resolve_import(&links[3], Lang::Python, &cur, &files),
+            Some(pb("pkg/up/__init__.py")),
+            ".. walks one package up"
+        );
+    }
+
+    #[test]
+    fn import_links_rust_forms_and_resolution() {
+        let src = "mod widgets;\nmod inline { }\nuse crate::views::browse;\nuse super::shared;\nuse std::path::Path;\nuse crate::util::{a, b};\nuse super::*;\n";
+        let links = import_links(src, Lang::Rust);
+        let targets: Vec<&str> = links.iter().map(|l| l.target.as_str()).collect();
+        assert_eq!(
+            targets,
+            [
+                "widgets",
+                "crate::views::browse",
+                "super::shared",
+                "std::path::Path",
+                "crate::util",
+                "super"
+            ],
+            "inline mod (has a body) is not a link; use lists/wildcards link their path prefix"
+        );
+        let files = [
+            pb("src/views/widgets.rs"),
+            pb("src/views/browse.rs"),
+            pb("src/shared.rs"),
+            pb("src/util/mod.rs"),
+        ];
+        let cur = pb("src/views/mod.rs");
+        assert_eq!(
+            resolve_import(&links[0], Lang::Rust, &cur, &files),
+            Some(pb("src/views/widgets.rs")),
+            "mod → sibling file"
+        );
+        assert_eq!(
+            resolve_import(&links[1], Lang::Rust, &cur, &files),
+            Some(pb("src/views/browse.rs")),
+            "crate:: from src/"
+        );
+        assert_eq!(
+            resolve_import(&links[2], Lang::Rust, &cur, &files),
+            Some(pb("src/shared.rs")),
+            "super:: from the parent module"
+        );
+        assert_eq!(
+            resolve_import(&links[3], Lang::Rust, &cur, &files),
+            None,
+            "std/external crates never resolve"
+        );
+        assert_eq!(
+            resolve_import(&links[4], Lang::Rust, &cur, &files),
+            Some(pb("src/util/mod.rs")),
+            "use list prefix → module dir"
+        );
+    }
+
+    #[test]
+    fn import_links_only_for_supported_langs() {
+        assert!(import_links("import x\n", Lang::PlainText).is_empty());
+        assert!(import_links("@import 'x';\n", Lang::Css).is_empty());
+        assert!(import_links("source ./x.sh\n", Lang::Bash).is_empty());
+    }
+
+    /// Performance regression guard — see CLAUDE.md "Performance regression tests".
+    /// `import_links` runs on every keystroke (alongside `highlight` +
+    /// `fold_regions`) when a language's cmd-click links are on, so it must stay
+    /// parse-speed on a large, import-heavy file.
+    #[test]
+    fn perf_import_links_large_file_stays_fast() {
+        let unit = "use crate::views::browse;\nmod widgets;\nfn f(x: i32) -> i32 { x + 1 }\n";
+        let src = unit.repeat(1500); // ~4500 lines, 3000 links
+        let start = std::time::Instant::now();
+        let links = import_links(&src, Lang::Rust);
+        let elapsed = start.elapsed();
+        assert_eq!(links.len(), 3000);
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "import_links on ~4500 lines took {elapsed:?} (budget 2s) — perf regression?"
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -565,6 +565,13 @@ impl Kyde {
             .is_some_and(|p| self.plugins.is_installed(p.id) && self.plugins.errors_on(p.id))
     }
 
+    /// Whether ⌘-click import navigation is on for `lang` (pack installed AND
+    /// the pack's links toggle on — default on, per-pack opt-out).
+    pub(crate) fn links_enabled_for(&self, lang: Lang) -> bool {
+        lang.pack()
+            .is_some_and(|p| self.plugins.is_installed(p.id) && self.plugins.links_on(p.id))
+    }
+
     /// Persist `rel`'s `text` to disk: through the repo's working tree in a git repo, else
     /// straight to disk under the project root (non-git Browse). Absolute paths (scratch
     /// files) write to themselves, since `join` keeps an absolute right-hand side. Returns

--- a/src/main.rs
+++ b/src/main.rs
@@ -898,6 +898,12 @@ struct BrowseView {
     /// Cmd-clicked FILE rows (ordered). Exactly two → the right-click menu
     /// offers "Compare Selected" (issue #42). Cleared by any plain click.
     multi_selected: Vec<PathBuf>,
+    /// Import targets the external-defs index was last computed for — the
+    /// cheap change gate (recompute only when the buffer's import set changes).
+    ext_defs_targets: Vec<String>,
+    /// Generation counter for the external-defs background job (stale results
+    /// from a superseded compute are dropped).
+    ext_defs_gen: u64,
     /// Scroll position of the tree, so "Select Opened File in Tree" can scroll an
     /// off-screen row into view.
     tree_scroll: ScrollHandle,
@@ -932,6 +938,9 @@ impl BrowseView {
                     this.browse.preview_tab = None;
                 }
                 this.autosave(cx);
+                // Import lines changed → re-index the imported files' definitions
+                // (cheap target-set comparison; the compute itself is background).
+                this.refresh_external_defs(cx);
             }
             // ⌘-click on an import link → resolve against the project file list
             // and open the target (issue #26).
@@ -940,6 +949,11 @@ impl BrowseView {
             // on the definition.
             EditorEvent::OpenSymbol { link, name } => {
                 this.open_import_symbol(link.clone(), name.clone(), cx);
+            }
+            // ⌘-click on a pre-resolved external definition (imported-files
+            // index) → open the file at the definition.
+            EditorEvent::OpenDefinition { path, range } => {
+                this.open_definition_at(path.clone(), range.clone(), cx);
             }
             EditorEvent::Changed => {}
         })
@@ -958,6 +972,8 @@ impl BrowseView {
             tab_scroll: ScrollHandle::new(),
             selected_path: None,
             multi_selected: Vec::new(),
+            ext_defs_targets: Vec::new(),
+            ext_defs_gen: 0,
             tree_scroll: ScrollHandle::new(),
             editor,
             editor_scroll: ScrollHandle::new(),
@@ -3126,6 +3142,50 @@ mod gpui_smoke_tests {
                 assert_eq!(k.browse.open_path, Some(PathBuf::from("lib.ts")));
                 let sel = k.browse.editor.read(cx).selection();
                 assert_eq!(&lib[sel], "answer", "selection lands on the definition");
+            })
+            .unwrap();
+    }
+
+    /// ⌘-click on a METHOD of an imported class resolves through the
+    /// external-defs index: the imported file's definitions are indexed in the
+    /// background, and clicking the method name opens that file at the method.
+    #[gpui::test]
+    fn cmd_click_method_resolves_via_imported_file(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        let lib = "export class Cat {\n  meow() { return 1; }\n}\n";
+        std::fs::write(dir.join("lib.ts"), lib).unwrap();
+        let main = "import { Cat } from './lib';\nnew Cat().meow();\n";
+        std::fs::write(dir.join("main.ts"), main).unwrap();
+        handle.update(cx, |k, _w, cx| k.refresh(cx)).unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, cx| {
+                k.plugins.install("typescript");
+                k.open_file(PathBuf::from("main.ts"), cx);
+                k.browse.editor.update(cx, |e, cx| {
+                    e.set_link_navigation(true, cx);
+                });
+                // open_file may have skipped the index (pack installed just
+                // now) — force a fresh compute with links enabled.
+                k.browse.ext_defs_targets.clear();
+                k.refresh_external_defs(cx);
+            })
+            .unwrap();
+        cx.run_until_parked(); // background index lands
+        handle
+            .update(cx, |k, _w, cx| {
+                // The editor's external index must now know `meow` → lib.ts.
+                let (path, range) = k
+                    .browse
+                    .editor
+                    .read(cx)
+                    .external_def_for("meow")
+                    .expect("method of the imported class is indexed");
+                assert_eq!(path, PathBuf::from("lib.ts"));
+                k.open_definition_at(path, range, cx);
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("lib.ts")));
+                let sel = k.browse.editor.read(cx).selection();
+                assert_eq!(&lib[sel], "meow", "selection lands on the method");
             })
             .unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -922,8 +922,8 @@ impl BrowseView {
     fn new(cx: &mut Context<Kyde>) -> Self {
         // No placeholder: an empty open file should read as empty, not show prompt text.
         let editor = cx.new(|cx| CodeEditor::new(cx, String::new(), Lang::PlainText, ""));
-        cx.subscribe(&editor, |this, _e, ev, cx| {
-            if matches!(ev, EditorEvent::Changed) && this.browse.editor.read(cx).dirty {
+        cx.subscribe(&editor, |this, _e, ev, cx| match ev {
+            EditorEvent::Changed if this.browse.editor.read(cx).dirty => {
                 // Editing a preview (temporary) tab promotes it to a permanent tab — VS Code
                 // behaviour, so the edit survives the next single-click elsewhere.
                 if this.browse.preview_tab.is_some()
@@ -933,6 +933,10 @@ impl BrowseView {
                 }
                 this.autosave(cx);
             }
+            // ⌘-click on an import link → resolve against the project file list
+            // and open the target (issue #26).
+            EditorEvent::OpenImport(link) => this.open_import_link(link.clone(), cx),
+            EditorEvent::Changed => {}
         })
         .detach();
         Self {
@@ -2421,6 +2425,16 @@ fn apply_shot(view: &mut Kyde, name: &str, window: &mut Window, cx: &mut Context
                 view.open_compare(PathBuf::from(a), PathBuf::from(b), cx);
             }
         }
+        // Browse a Rust file with ⌘ "held" over an import — the link underlines
+        // (issue #26). Uses the debug hover forcer since shots can't hold keys.
+        "imports" => {
+            set_packs(view, &["rust"]);
+            view.open_file(PathBuf::from("src/main.rs"), cx);
+            view.browse.editor.update(cx, |e, cx| {
+                e.force_link_hover(0);
+                cx.notify();
+            });
+        }
         // History view: the commit log for the current branch, first commit selected so the
         // changed-files list + read-only diff are populated.
         "history" => {
@@ -3038,6 +3052,40 @@ mod gpui_smoke_tests {
                     "one\nTWO\nthree\n"
                 );
                 assert!(k.compare.diff.as_ref().unwrap().hunks.is_empty());
+            })
+            .unwrap();
+    }
+
+    /// ⌘-click import navigation (issue #26): a link resolved against the
+    /// project file list opens the target; unresolvable specifiers (packages)
+    /// are a silent no-op.
+    #[gpui::test]
+    fn cmd_click_import_opens_the_target_file(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        std::fs::write(dir.join("lib.ts"), "export const a = 1;\n").unwrap();
+        std::fs::write(dir.join("main.ts"), "import { a } from './lib';\n").unwrap();
+        handle.update(cx, |k, _w, cx| k.refresh(cx)).unwrap();
+        cx.run_until_parked(); // let the file-list snapshot land
+        handle
+            .update(cx, |k, _w, cx| {
+                k.open_file(PathBuf::from("main.ts"), cx);
+                // Lang set explicitly — must not depend on the machine's installed packs.
+                k.browse.editor.update(cx, |e, cx| {
+                    e.set_link_navigation(true, cx);
+                    e.set_content("import { a } from './lib';\n".into(), Lang::Ts, cx);
+                });
+                let links = highlight::import_links("import { a } from './lib';\n", Lang::Ts);
+                assert_eq!(links.len(), 1);
+                k.open_import_link(links[0].clone(), cx);
+                assert_eq!(
+                    k.browse.open_path,
+                    Some(PathBuf::from("lib.ts")),
+                    "relative TS import resolves + opens"
+                );
+                // A bare specifier is an npm package — no-op.
+                let npm = highlight::import_links("import r from 'react';\n", Lang::Ts);
+                k.open_import_link(npm[0].clone(), cx);
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("lib.ts")));
             })
             .unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -936,6 +936,11 @@ impl BrowseView {
             // ⌘-click on an import link → resolve against the project file list
             // and open the target (issue #26).
             EditorEvent::OpenImport(link) => this.open_import_link(link.clone(), cx),
+            // ⌘-click on a USE of an imported symbol → open its file and land
+            // on the definition.
+            EditorEvent::OpenSymbol { link, name } => {
+                this.open_import_symbol(link.clone(), name.clone(), cx);
+            }
             EditorEvent::Changed => {}
         })
         .detach();
@@ -3086,6 +3091,41 @@ mod gpui_smoke_tests {
                 let npm = highlight::import_links("import r from 'react';\n", Lang::Ts);
                 k.open_import_link(npm[0].clone(), cx);
                 assert_eq!(k.browse.open_path, Some(PathBuf::from("lib.ts")));
+            })
+            .unwrap();
+    }
+
+    /// ⌘-click on a USE of an imported symbol jumps THROUGH the import: opens
+    /// the target file and lands the selection on the definition. The pack for
+    /// the target must be installed (effective lang drives the definition scan).
+    #[gpui::test]
+    fn cmd_click_symbol_jumps_to_its_definition(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        let lib = "const pad = 1;\nexport const answer = 42;\n";
+        std::fs::write(dir.join("lib.ts"), lib).unwrap();
+        std::fs::write(
+            dir.join("main.ts"),
+            "import { answer } from './lib';\nconsole.log(answer);\n",
+        )
+        .unwrap();
+        handle.update(cx, |k, _w, cx| k.refresh(cx)).unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, cx| {
+                k.plugins.install("typescript"); // effective_lang must see Ts for lib.ts
+                k.open_file(PathBuf::from("main.ts"), cx);
+                let src = "import { answer } from './lib';\nconsole.log(answer);\n";
+                k.browse.editor.update(cx, |e, cx| {
+                    e.set_link_navigation(true, cx);
+                    e.set_content(src.into(), Lang::Ts, cx);
+                });
+                let binds = highlight::import_bindings(src, Lang::Ts);
+                let (name, link) = binds[0].clone();
+                assert_eq!(name, "answer");
+                k.open_import_symbol(link, name, cx);
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("lib.ts")));
+                let sel = k.browse.editor.read(cx).selection();
+                assert_eq!(&lib[sel], "answer", "selection lands on the definition");
             })
             .unwrap();
     }

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -1032,4 +1032,38 @@ impl Kyde {
             self.open_file(target, cx);
         }
     }
+
+    /// ⌘-click on a USE of an imported symbol: open the import's file (a new
+    /// tab if not already open) and land the caret on `name`'s definition
+    /// there. No definition found (or unresolvable module) → the file still
+    /// opens (or nothing happens), never an error.
+    pub(crate) fn open_import_symbol(
+        &mut self,
+        link: highlight::ImportLink,
+        name: String,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(cur) = self.browse.open_path.clone() else {
+            return;
+        };
+        let lang = self.browse.editor.read(cx).lang;
+        let Some(target) = highlight::resolve_import(&link, lang, &cur, &self.browse.all_files)
+        else {
+            return;
+        };
+        self.open_file(target.clone(), cx);
+        // The editor now holds the target file — find the symbol's definition in
+        // its (possibly PlainText-gated) effective language and select it.
+        let tl = self.effective_lang(&target);
+        let def = {
+            let ed = self.browse.editor.read(cx);
+            highlight::definition_sites(ed.text(), tl)
+                .into_iter()
+                .find(|(n, _)| *n == name)
+                .map(|(_, r)| r)
+        };
+        if let Some(r) = def {
+            self.browse.editor.update(cx, |e, cx| e.select_range(r, cx));
+        }
+    }
 }

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -848,11 +848,13 @@ impl Kyde {
             };
             let lang = self.effective_lang(&rel);
             let errs = self.errors_enabled_for(lang);
+            let links = self.links_enabled_for(lang);
             self.browse.editor.update(cx, |e, cx| {
                 e.line_numbers = true;
-                // Flag first so `set_content`'s recompute already parses (or skips)
-                // errors for the new file's opt-in.
+                // Flags first so `set_content`'s recompute already parses (or
+                // skips) errors/links for the new file's toggles.
                 e.set_error_highlight(errs, cx);
+                e.set_link_navigation(links, cx);
                 e.set_content(content, lang, cx);
             });
             // Point the editor at whichever scroll container it renders in, so caret-follow
@@ -1015,5 +1017,19 @@ impl Kyde {
         cx: &mut Context<Self>,
     ) {
         self.sort_object_keys_at_caret(cx);
+    }
+
+    // ── ⌘-click import navigation (issue #26) ─────────────────────
+    /// Resolve a ⌘-clicked import against the project's file list and open the
+    /// target file. Unresolvable specifiers (npm packages, external crates,
+    /// stdlib modules) are a silent no-op.
+    pub(crate) fn open_import_link(&mut self, link: highlight::ImportLink, cx: &mut Context<Self>) {
+        let Some(cur) = self.browse.open_path.clone() else {
+            return;
+        };
+        let lang = self.browse.editor.read(cx).lang;
+        if let Some(target) = highlight::resolve_import(&link, lang, &cur, &self.browse.all_files) {
+            self.open_file(target, cx);
+        }
     }
 }

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -857,6 +857,10 @@ impl Kyde {
                 e.set_link_navigation(links, cx);
                 e.set_content(content, lang, cx);
             });
+            // New buffer → the previous file's imported-defs index is gone
+            // (set_content cleared it); force a fresh compute for this file.
+            self.browse.ext_defs_targets.clear();
+            self.refresh_external_defs(cx);
             // Point the editor at whichever scroll container it renders in, so caret-follow
             // and drag auto-scroll move the right one: the Markdown split uses
             // `md_editor_scroll`, plain Browse uses `file_scroll` (mirrors the `md` gate in
@@ -1031,6 +1035,97 @@ impl Kyde {
         if let Some(target) = highlight::resolve_import(&link, lang, &cur, &self.browse.all_files) {
             self.open_file(target, cx);
         }
+    }
+
+    /// ⌘-click on a symbol the external-defs index already resolved (a method
+    /// on an imported class): open the file and select the definition.
+    pub(crate) fn open_definition_at(
+        &mut self,
+        path: PathBuf,
+        range: std::ops::Range<usize>,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_file(path, cx);
+        self.browse
+            .editor
+            .update(cx, |e, cx| e.select_range(range, cx));
+    }
+
+    /// (Re)build the imported-files definition index for the open buffer —
+    /// resolves each import to a project file, reads + indexes those files'
+    /// definitions IN THE BACKGROUND, and pushes the map into the editor
+    /// (`set_external_defs`). Skips recomputing when the buffer's import
+    /// target set hasn't changed. This is what lets ⌘-click resolve
+    /// `obj.method()` when the method lives with an imported class.
+    pub(crate) fn refresh_external_defs(&mut self, cx: &mut Context<Self>) {
+        let Some(cur) = self.browse.open_path.clone() else {
+            return;
+        };
+        let lang = self.effective_lang(&cur);
+        if !self.links_enabled_for(lang) {
+            return;
+        }
+        let targets = self.browse.editor.read(cx).import_targets();
+        if targets == self.browse.ext_defs_targets {
+            return; // same imports → index still valid
+        }
+        self.browse.ext_defs_targets = targets;
+        self.browse.ext_defs_gen = self.browse.ext_defs_gen.wrapping_add(1);
+        let gen = self.browse.ext_defs_gen;
+        // Resolve on the UI thread (cheap, needs all_files); read + parse the
+        // handful of target files on a background thread. Files are read from
+        // disk via the project root — kyde autosaves every edit, so disk is
+        // current.
+        let content = self.browse.editor.read(cx).text().to_string();
+        let files = self.browse.all_files.clone();
+        let root = self.repo_root.clone();
+        cx.spawn(async move |this, cx| {
+            let map = cx
+                .background_executor()
+                .spawn(async move {
+                    let mut map: std::collections::HashMap<
+                        String,
+                        (PathBuf, std::ops::Range<usize>),
+                    > = std::collections::HashMap::new();
+                    let mut seen: std::collections::HashSet<PathBuf> =
+                        std::collections::HashSet::new();
+                    for link in highlight::import_links(&content, lang) {
+                        let Some(target) = highlight::resolve_import(&link, lang, &cur, &files)
+                        else {
+                            continue;
+                        };
+                        if !seen.insert(target.clone()) {
+                            continue;
+                        }
+                        let abs = match (&root, target.is_absolute()) {
+                            (_, true) => target.clone(),
+                            (Some(r), false) => r.join(&target),
+                            (None, false) => continue,
+                        };
+                        let Ok(text) = std::fs::read_to_string(&abs) else {
+                            continue;
+                        };
+                        // Index under the TARGET file's own language (same
+                        // grammar family in practice for TS/JS mixes).
+                        let tl = Lang::from_path(&target);
+                        for (name, r) in highlight::definition_sites(&text, tl) {
+                            // First definition wins (files in import order).
+                            map.entry(name).or_insert((target.clone(), r));
+                        }
+                    }
+                    map
+                })
+                .await;
+            this.update(cx, |k, cx| {
+                if k.browse.ext_defs_gen == gen {
+                    k.browse
+                        .editor
+                        .update(cx, |e, cx| e.set_external_defs(map, cx));
+                }
+            })
+            .ok();
+        })
+        .detach();
     }
 
     /// ⌘-click on a USE of an imported symbol: open the import's file (a new

--- a/src/views/modals.rs
+++ b/src/views/modals.rs
@@ -157,28 +157,48 @@ impl Kyde {
                                     .child(SharedString::from(pack_size(p.id))),
                             ),
                     )
-                    // Per-pack error-highlighting opt-in — only meaningful once the
-                    // grammar is active ("font" isn't a language, no parse to check).
+                    // Per-pack feature toggles (default on) — only meaningful once
+                    // the grammar is active ("font" isn't a language, no parse).
                     .when(installed && id != "font", |row| {
-                        let errs_on = self.plugins.errors_on(id);
-                        row.child(
+                        let check = |label: &'static str,
+                                     on: bool,
+                                     toggle: fn(&mut Self, &str, &mut Context<Self>),
+                                     cx: &mut Context<Self>| {
                             div()
                                 .flex()
                                 .flex_row()
                                 .items_center()
                                 .gap_2()
-                                .flex_none()
                                 .cursor_pointer()
                                 .text_size(px(11.0))
                                 .text_color(t.secondary_text)
-                                .child(checkbox_box(errs_on))
-                                .child("Error highlighting")
+                                .child(checkbox_box(on))
+                                .child(label)
                                 .on_mouse_down(
                                     MouseButton::Left,
-                                    cx.listener(move |this, _e, _w, cx| {
-                                        this.toggle_pack_errors(id, cx);
-                                    }),
-                                ),
+                                    cx.listener(move |this, _e, _w, cx| toggle(this, id, cx)),
+                                )
+                        };
+                        let errs = check(
+                            "Error highlighting",
+                            self.plugins.errors_on(id),
+                            Kyde::toggle_pack_errors,
+                            cx,
+                        );
+                        let links = check(
+                            "⌘-click imports",
+                            self.plugins.links_on(id),
+                            Kyde::toggle_pack_links,
+                            cx,
+                        );
+                        row.child(
+                            div()
+                                .flex()
+                                .flex_col()
+                                .gap_1()
+                                .flex_none()
+                                .child(errs)
+                                .child(links),
                         )
                     })
                     .child(btn)
@@ -574,8 +594,10 @@ impl Kyde {
             // Re-highlight in place so the colors appear immediately — previously this only
             // set the lang, leaving the cached (plain) spans until the file was reopened.
             let errs = self.errors_enabled_for(lang);
+            let links = self.links_enabled_for(lang);
             self.browse.editor.update(cx, |e, cx| {
                 e.set_error_highlight(errs, cx);
+                e.set_link_navigation(links, cx);
                 e.set_lang(lang, cx);
             });
         }
@@ -628,8 +650,10 @@ impl Kyde {
         } else if let Some(rel) = self.browse.open_path.clone() {
             let eff = self.effective_lang(&rel);
             let errs = self.errors_enabled_for(eff);
+            let links = self.links_enabled_for(eff);
             self.browse.editor.update(cx, |e, cx| {
                 e.set_error_highlight(errs, cx);
+                e.set_link_navigation(links, cx);
                 e.set_lang(eff, cx);
             });
         }
@@ -651,8 +675,10 @@ impl Kyde {
             if lang.pack().map(|p| p.id) == Some(pack_id) {
                 let eff = self.effective_lang(&rel);
                 let errs = self.errors_enabled_for(eff);
+                let links = self.links_enabled_for(eff);
                 self.browse.editor.update(cx, |e, cx| {
                     e.set_error_highlight(errs, cx);
+                    e.set_link_navigation(links, cx);
                     e.set_lang(eff, cx);
                 });
             }
@@ -673,6 +699,23 @@ impl Kyde {
                 self.browse
                     .editor
                     .update(cx, |e, cx| e.set_error_highlight(on, cx));
+            }
+        }
+        cx.notify();
+    }
+
+    /// Toggle a pack's ⌘-click import navigation (default on, per-pack opt-out),
+    /// persist it, and apply to the open file in place.
+    pub(crate) fn toggle_pack_links(&mut self, pack_id: &str, cx: &mut Context<Self>) {
+        let on = !self.plugins.links_on(pack_id);
+        self.plugins.set_links(pack_id, on);
+        self.plugins.save();
+        if let Some(rel) = self.browse.open_path.clone() {
+            let eff = self.effective_lang(&rel);
+            if eff.pack().map(|p| p.id) == Some(pack_id) {
+                self.browse
+                    .editor
+                    .update(cx, |e, cx| e.set_link_navigation(on, cx));
             }
         }
         cx.notify();

--- a/src/widgets/editor/element.rs
+++ b/src/widgets/editor/element.rs
@@ -120,15 +120,11 @@ impl Element for EditorElement {
         // rows never pay for the run splitting.
         let errors: &[std::ops::Range<usize>] = if empty { &[] } else { &editor.error_ranges };
         let error_color: Hsla = theme::get().syn_error.into();
-        // The ⌘-hovered import link (at most one) gets a straight underline in
-        // the accent color — the visible "this is clickable" affordance.
+        // The ⌘-hovered symbol (at most one — an import link or a navigable
+        // identifier) gets a straight underline in the accent color — the
+        // visible "this is clickable" affordance.
         let link_range: Option<[std::ops::Range<usize>; 1]> = (editor.cmd_held && !empty)
-            .then(|| {
-                editor
-                    .hover_link
-                    .and_then(|i| editor.import_links.get(i))
-                    .map(|l| [l.range.clone()])
-            })
+            .then(|| editor.hover_range.clone().map(|r| [r]))
             .flatten();
         let link_style = UnderlineStyle {
             thickness: px(1.0),

--- a/src/widgets/editor/element.rs
+++ b/src/widgets/editor/element.rs
@@ -120,6 +120,21 @@ impl Element for EditorElement {
         // rows never pay for the run splitting.
         let errors: &[std::ops::Range<usize>] = if empty { &[] } else { &editor.error_ranges };
         let error_color: Hsla = theme::get().syn_error.into();
+        // The ⌘-hovered import link (at most one) gets a straight underline in
+        // the accent color — the visible "this is clickable" affordance.
+        let link_range: Option<[std::ops::Range<usize>; 1]> = (editor.cmd_held && !empty)
+            .then(|| {
+                editor
+                    .hover_link
+                    .and_then(|i| editor.import_links.get(i))
+                    .map(|l| [l.range.clone()])
+            })
+            .flatten();
+        let link_style = UnderlineStyle {
+            thickness: px(1.0),
+            color: Some(theme::get().primary.into()),
+            wavy: false,
+        };
 
         // Byte offset of every buffer line start — ONE pass over the content per frame.
         // (Previously the content was `split('\n')`-scanned 3-4× per frame — for a 37k-line
@@ -270,13 +285,22 @@ impl Element for EditorElement {
                         line_starts.push(start + seg);
                         visible_lines.push(b);
                         if on_screen(dr) {
-                            let s_runs = apply_error_squiggles(
+                            let mut s_runs = apply_error_squiggles(
                                 line_runs(seg_str, start + seg, spans, &font, default_color),
                                 start + seg,
                                 seg_str.len(),
                                 errors,
                                 error_color,
                             );
+                            if let Some(lr) = &link_range {
+                                s_runs = apply_underline_ranges(
+                                    s_runs,
+                                    start + seg,
+                                    seg_str.len(),
+                                    lr,
+                                    link_style,
+                                );
+                            }
                             lines.insert(
                                 dr,
                                 window.text_system().shape_line(
@@ -298,13 +322,16 @@ impl Element for EditorElement {
                     gutter.push((dr, editor.folded.contains(&b)));
                 }
                 if on_screen(dr) {
-                    let runs = apply_error_squiggles(
+                    let mut runs = apply_error_squiggles(
                         line_runs(line, start, spans, &font, default_color),
                         start,
                         line.len(),
                         errors,
                         error_color,
                     );
+                    if let Some(lr) = &link_range {
+                        runs = apply_underline_ranges(runs, start, line.len(), lr, link_style);
+                    }
                     lines.insert(
                         dr,
                         window.text_system().shape_line(

--- a/src/widgets/editor/mod.rs
+++ b/src/widgets/editor/mod.rs
@@ -251,6 +251,9 @@ pub struct CodeEditor {
     /// Current pointer position during a drag-select, so the auto-scroll loop can keep
     /// extending the selection while the pointer is held past an edge (no mouse-move events).
     drag_pos: Option<Point<Pixels>>,
+    /// Last pointer position over the editor (any state) — pressing ⌘ while the
+    /// mouse is stationary still lights up the import link under it.
+    last_mouse: Option<Point<Pixels>>,
     /// True while the drag auto-scroll loop is running, so we never spawn a second one.
     autoscroll_active: bool,
     /// Held vertical-nav key as `(direction, extend-selection)` — `Some` while ↑/↓ (or
@@ -349,6 +352,7 @@ impl CodeEditor {
             reveal_pending: false,
             viewport: None,
             drag_pos: None,
+            last_mouse: None,
             autoscroll_active: false,
             nav: None,
             nav_active: false,
@@ -600,9 +604,29 @@ impl CodeEditor {
 
     /// Index of the import link containing byte offset `off`, if any.
     fn link_at(&self, off: usize) -> Option<usize> {
-        self.import_links
-            .iter()
-            .position(|l| l.range.start <= off && off < l.range.end)
+        // `import_links` is sorted by range start — binary-search the candidate.
+        let i = self
+            .import_links
+            .partition_point(|l| l.range.start <= off)
+            .checked_sub(1)?;
+        (off < self.import_links[i].range.end).then_some(i)
+    }
+
+    /// Recompute which import link the pointer sits on (from `last_mouse`),
+    /// honoring the ⌘ + toggle gates; notifies only on change. Called from
+    /// mouse-move AND `ModifiersChanged`, so pressing ⌘ over a link lights it up
+    /// without needing the mouse to move first.
+    fn refresh_link_hover(&mut self, cx: &mut Context<Self>) {
+        let hit = match self.last_mouse {
+            Some(pos) if self.cmd_held && self.links_on && !self.is_selecting => {
+                self.link_at(self.offset_for_position(pos))
+            }
+            _ => None,
+        };
+        if hit != self.hover_link {
+            self.hover_link = hit;
+            cx.notify();
+        }
     }
 
     /// Screenshot/debug helper: force the ⌘-hover affordance on import link `i`,
@@ -1113,15 +1137,16 @@ impl CodeEditor {
         }
     }
     fn on_mouse_move(&mut self, ev: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
-        // ⌘-hover over an import link → underline + pointer cursor (the hover
-        // clears when ⌘ lifts — see the ModifiersChanged listener).
-        if self.cmd_held && self.links_on && !self.is_selecting {
-            let hit = self.link_at(self.offset_for_position(ev.position));
-            if hit != self.hover_link {
-                self.hover_link = hit;
-                cx.notify();
-            }
+        // ⌘-hover over an import link → underline + pointer cursor. The ⌘ state
+        // rides the move event itself (`ev.modifiers`) — a ModifiersChanged
+        // event only reaches us via the focus path, which is unreliable when the
+        // pointer roams unfocused panes; the move event always knows.
+        self.last_mouse = Some(ev.position);
+        if self.cmd_held != ev.modifiers.platform {
+            self.cmd_held = ev.modifiers.platform;
+            cx.notify();
         }
+        self.refresh_link_hover(cx);
         // Only extend the selection for a drag this editor itself started.
         if self.is_selecting && ev.dragging() {
             // `select_to` sets `reveal_pending`, which would yank the view back to the
@@ -1618,9 +1643,9 @@ impl Render for CodeEditor {
                     let held = e.modifiers.platform;
                     if this.cmd_held != held {
                         this.cmd_held = held;
-                        if !held {
-                            this.hover_link = None;
-                        }
+                        // Pressing ⌘ over a link (pointer stationary) lights it
+                        // up immediately; releasing clears it.
+                        this.refresh_link_hover(cx);
                         cx.notify();
                     }
                 }),

--- a/src/widgets/editor/mod.rs
+++ b/src/widgets/editor/mod.rs
@@ -122,6 +122,47 @@ pub enum EditorEvent {
     /// ⌘-click landed on an import link — the app resolves the target against
     /// the project's file list and opens it (issue #26).
     OpenImport(highlight::ImportLink),
+    /// ⌘-click landed on a USE of an imported symbol — the app opens the
+    /// import's file and jumps to `name`'s definition inside it.
+    OpenSymbol {
+        /// The import that binds the symbol (resolves to the target file).
+        link: highlight::ImportLink,
+        /// The symbol to land on in that file.
+        name: String,
+    },
+}
+
+/// What a ⌘-click at some offset targets (see `CodeEditor::symbol_at`).
+enum SymbolTarget {
+    /// The import specifier itself → open the referenced file.
+    Link(highlight::ImportLink),
+    /// A symbol defined in THIS buffer → jump to its definition range.
+    LocalDef(Range<usize>),
+    /// A use of an imported symbol → open its file, land on the definition.
+    ImportedSymbol(highlight::ImportLink, String),
+}
+
+/// The ⌘-click navigation caches, computed together on one parse-adjacent pass:
+/// the import links (sorted), the imported-name → link map, and the
+/// definition-site index (name → sorted name-ranges).
+type NavCaches = (
+    Vec<highlight::ImportLink>,
+    std::collections::HashMap<String, highlight::ImportLink>,
+    std::collections::HashMap<String, Vec<Range<usize>>>,
+);
+
+/// Build the navigation caches for `source` (see [`NavCaches`]).
+fn compute_nav(source: &str, lang: Lang) -> NavCaches {
+    let links = highlight::import_links(source, lang);
+    let bound = highlight::import_bindings(source, lang)
+        .into_iter()
+        .collect();
+    let mut defs: std::collections::HashMap<String, Vec<Range<usize>>> =
+        std::collections::HashMap::new();
+    for (name, r) in highlight::definition_sites(source, lang) {
+        defs.entry(name).or_default().push(r);
+    }
+    (links, bound, defs)
 }
 
 /// A point-in-time editor state for the undo/redo stacks.
@@ -202,15 +243,21 @@ pub struct CodeEditor {
     /// Cached import links (sorted by position), recomputed with `spans` — but
     /// ONLY when `links_on`, so editors without the toggle never pay the parse.
     import_links: Vec<highlight::ImportLink>,
-    /// ⌘-click import navigation for this editor's language (same push model as
-    /// `errors_on`: per-pack toggle, on by default for installed packs).
+    /// Names bound by imports → their link, for jump-through-the-import on a
+    /// USE of an imported symbol. Recomputed with `import_links`.
+    import_bound: std::collections::HashMap<String, highlight::ImportLink>,
+    /// Definition sites (name → sorted name-ranges), for same-file
+    /// go-to-definition. Recomputed with `import_links`.
+    defs: std::collections::HashMap<String, Vec<Range<usize>>>,
+    /// ⌘-click navigation (imports + definitions) for this editor's language
+    /// (same push model as `errors_on`: per-pack toggle, default on).
     links_on: bool,
-    /// Live ⌘-held state (tracked via `ModifiersChanged`) — gates the link hover
+    /// Live ⌘-held state (tracked via `ModifiersChanged`) — gates the hover
     /// affordance and the click intercept.
     cmd_held: bool,
-    /// Index into `import_links` under the pointer while ⌘ is held (drives the
-    /// underline + pointer cursor).
-    hover_link: Option<usize>,
+    /// Byte range under the pointer that ⌘-click would act on (an import link
+    /// or a symbol with a known target) — drives the underline + pointer cursor.
+    hover_range: Option<Range<usize>>,
     /// Longest line length in bytes (recomputed on content change) — drives the element's
     /// content width so long lines scroll horizontally instead of clipping.
     max_line_len: usize,
@@ -335,9 +382,11 @@ impl CodeEditor {
             error_ranges: Vec::new(),
             errors_on: false,
             import_links: Vec::new(),
+            import_bound: std::collections::HashMap::new(),
+            defs: std::collections::HashMap::new(),
             links_on: false,
             cmd_held: false,
-            hover_link: None,
+            hover_range: None,
             max_line_len: 0,
             line_layouts: HashMap::new(),
             display_rows: 0,
@@ -494,15 +543,17 @@ impl CodeEditor {
             self.spans = Vec::new();
             self.error_ranges = Vec::new();
             self.import_links = Vec::new();
-            self.hover_link = None;
+            self.import_bound.clear();
+            self.defs.clear();
+            self.hover_range = None;
             self.foldable = Vec::new();
             self.foldable_starts.clear();
             self.max_line_len = 0;
             return;
         }
-        self.hover_link = None; // ranges may have shifted under the pointer
-                                // Longest line (bytes) → element content width for horizontal scroll. Cheap byte
-                                // scan, only on content change (not per frame).
+        self.hover_range = None; // ranges may have shifted under the pointer
+                                 // Longest line (bytes) → element content width for horizontal scroll. Cheap byte
+                                 // scan, only on content change (not per frame).
         self.max_line_len = self.content.split('\n').map(str::len).max().unwrap_or(0);
         // Small files: highlight + find folds inline (correct on the very first frame, no
         // flicker). Big files: clear now so the file opens instantly as plain text, then
@@ -521,11 +572,14 @@ impl CodeEditor {
             } else {
                 Vec::new()
             };
-            self.import_links = if self.links_on {
-                highlight::import_links(&self.content, self.lang)
+            let (links, bound, defs) = if self.links_on {
+                compute_nav(&self.content, self.lang)
             } else {
-                Vec::new()
+                Default::default()
             };
+            self.import_links = links;
+            self.import_bound = bound;
+            self.defs = defs;
             self.foldable = highlight::fold_regions(&self.content, self.lang);
             self.foldable_starts = self.foldable.iter().map(|r| r.0).collect();
             self.folded.retain(|l| self.foldable_starts.contains(l));
@@ -534,6 +588,8 @@ impl CodeEditor {
         self.spans = Vec::new();
         self.error_ranges = Vec::new();
         self.import_links = Vec::new();
+        self.import_bound.clear();
+        self.defs.clear();
         self.foldable = Vec::new();
         self.foldable_starts.clear();
         let gen = self.compute_gen;
@@ -542,7 +598,7 @@ impl CodeEditor {
         let errors_on = self.errors_on;
         let links_on = self.links_on;
         cx.spawn(async move |this, cx| {
-            let (spans, foldable, errors, links) = cx
+            let (spans, foldable, errors, nav) = cx
                 .background_executor()
                 .spawn(async move {
                     (
@@ -554,9 +610,9 @@ impl CodeEditor {
                             Vec::new()
                         },
                         if links_on {
-                            highlight::import_links(&content, lang)
+                            compute_nav(&content, lang)
                         } else {
-                            Vec::new()
+                            Default::default()
                         },
                     )
                 })
@@ -566,7 +622,7 @@ impl CodeEditor {
                     // Still the current content → apply the highlight + folds.
                     ed.spans = spans;
                     ed.error_ranges = errors;
-                    ed.import_links = links;
+                    (ed.import_links, ed.import_bound, ed.defs) = nav;
                     ed.foldable_starts = foldable.iter().map(|r| r.0).collect();
                     ed.foldable = foldable;
                     ed.folded.retain(|l| ed.foldable_starts.contains(l));
@@ -612,19 +668,67 @@ impl CodeEditor {
         (off < self.import_links[i].range.end).then_some(i)
     }
 
-    /// Recompute which import link the pointer sits on (from `last_mouse`),
-    /// honoring the ⌘ + toggle gates; notifies only on change. Called from
-    /// mouse-move AND `ModifiersChanged`, so pressing ⌘ over a link lights it up
-    /// without needing the mouse to move first.
+    /// The word (identifier: alphanumeric/`_` run) containing byte offset `off`.
+    fn word_range_at(&self, off: usize) -> Option<Range<usize>> {
+        let bytes = self.content.as_bytes();
+        let off = off.min(self.content.len());
+        let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+        if off >= bytes.len() || !is_word(bytes[off]) {
+            return None;
+        }
+        let mut start = off;
+        while start > 0 && is_word(bytes[start - 1]) {
+            start -= 1;
+        }
+        let mut end = off;
+        while end < bytes.len() && is_word(bytes[end]) {
+            end += 1;
+        }
+        Some(start..end)
+    }
+
+    /// What ⌘-click at `off` would act on: an import link's specifier, a USE of
+    /// an imported symbol (jump through to its file), or a symbol defined in
+    /// this buffer (jump to the definition). Returns the range to underline plus
+    /// the action. A definition site itself doesn't self-target.
+    fn symbol_at(&self, off: usize) -> Option<(Range<usize>, SymbolTarget)> {
+        if let Some(i) = self.link_at(off) {
+            let l = &self.import_links[i];
+            return Some((l.range.clone(), SymbolTarget::Link(l.clone())));
+        }
+        let word = self.word_range_at(off)?;
+        let name = &self.content[word.clone()];
+        // Definitions win over import bindings: shadowing (a local `let x` over
+        // an imported `x`) resolves locally, like the compiler would.
+        if let Some(sites) = self.defs.get(name) {
+            if let Some(def) = sites.iter().find(|r| **r != word) {
+                return Some((word.clone(), SymbolTarget::LocalDef(def.clone())));
+            }
+        }
+        if let Some(link) = self.import_bound.get(name) {
+            // The imported name itself (in the import statement) rides the
+            // link range already; a USE elsewhere jumps through the import.
+            return Some((
+                word.clone(),
+                SymbolTarget::ImportedSymbol(link.clone(), name.to_string()),
+            ));
+        }
+        None
+    }
+
+    /// Recompute what the pointer sits on (from `last_mouse`), honoring the ⌘ +
+    /// toggle gates; notifies only on change. Called from mouse-move AND
+    /// `ModifiersChanged`, so pressing ⌘ over a symbol lights it up without
+    /// needing the mouse to move first.
     fn refresh_link_hover(&mut self, cx: &mut Context<Self>) {
         let hit = match self.last_mouse {
-            Some(pos) if self.cmd_held && self.links_on && !self.is_selecting => {
-                self.link_at(self.offset_for_position(pos))
-            }
+            Some(pos) if self.cmd_held && self.links_on && !self.is_selecting => self
+                .symbol_at(self.offset_for_position(pos))
+                .map(|(r, _)| r),
             _ => None,
         };
-        if hit != self.hover_link {
-            self.hover_link = hit;
+        if hit != self.hover_range {
+            self.hover_range = hit;
             cx.notify();
         }
     }
@@ -634,8 +738,8 @@ impl CodeEditor {
     /// whether such a link exists (false = nothing will underline).
     pub fn force_link_hover(&mut self, i: usize) -> bool {
         self.cmd_held = true;
-        self.hover_link = Some(i);
-        self.import_links.len() > i
+        self.hover_range = self.import_links.get(i).map(|l| l.range.clone());
+        self.hover_range.is_some()
     }
 
     /// (Re)start the caret blink: show it now and bump the epoch so any prior blink loop exits,
@@ -1031,14 +1135,28 @@ impl CodeEditor {
         // IME text can route here incidentally while actions (cmd-z, etc.) don't dispatch.
         self.focus_handle.focus(window);
         self.restart_blink(cx);
-        // ⌘-click on an import link opens the target file (issue #26) instead of
-        // moving the caret.
+        // ⌘-click navigation (issue #26): an import specifier opens its file, a
+        // locally-defined symbol jumps to its definition here, and a use of an
+        // imported symbol jumps through the import to the definition over there.
         if ev.modifiers.platform && self.links_on {
             let off = self.offset_for_position(ev.position);
-            if let Some(i) = self.link_at(off) {
-                cx.emit(EditorEvent::OpenImport(self.import_links[i].clone()));
-                cx.stop_propagation();
-                return;
+            match self.symbol_at(off) {
+                Some((_, SymbolTarget::Link(link))) => {
+                    cx.emit(EditorEvent::OpenImport(link));
+                    cx.stop_propagation();
+                    return;
+                }
+                Some((_, SymbolTarget::LocalDef(def))) => {
+                    self.select_range(def, cx);
+                    cx.stop_propagation();
+                    return;
+                }
+                Some((_, SymbolTarget::ImportedSymbol(link, name))) => {
+                    cx.emit(EditorEvent::OpenSymbol { link, name });
+                    cx.stop_propagation();
+                    return;
+                }
+                None => {}
             }
         }
         // A click in the fold gutter toggles the fold on that display row instead
@@ -1590,7 +1708,7 @@ impl Render for CodeEditor {
             .key_context(ctx.as_str())
             .track_focus(&self.focus_handle)
             // Pointer over a ⌘-hovered import link (it's clickable); I-beam otherwise.
-            .cursor(if self.cmd_held && self.hover_link.is_some() {
+            .cursor(if self.cmd_held && self.hover_range.is_some() {
                 CursorStyle::PointingHand
             } else {
                 CursorStyle::IBeam

--- a/src/widgets/editor/mod.rs
+++ b/src/widgets/editor/mod.rs
@@ -130,6 +130,15 @@ pub enum EditorEvent {
         /// The symbol to land on in that file.
         name: String,
     },
+    /// ⌘-click landed on a symbol pre-resolved to a definition in another file
+    /// (the external-defs index — e.g. a method on an imported class): the app
+    /// opens `path` and selects `range`.
+    OpenDefinition {
+        /// Target file (repo-relative / absolute-scratch, like open paths).
+        path: std::path::PathBuf,
+        /// The definition name's byte range in that file.
+        range: Range<usize>,
+    },
 }
 
 /// What a ⌘-click at some offset targets (see `CodeEditor::symbol_at`).
@@ -140,6 +149,9 @@ enum SymbolTarget {
     LocalDef(Range<usize>),
     /// A use of an imported symbol → open its file, land on the definition.
     ImportedSymbol(highlight::ImportLink, String),
+    /// A symbol defined in a file this buffer imports (method on an imported
+    /// class, helper next to it, …) → open that file at the definition.
+    ExternalDef(std::path::PathBuf, Range<usize>),
 }
 
 /// The ⌘-click navigation caches, computed together on one parse-adjacent pass:
@@ -249,6 +261,12 @@ pub struct CodeEditor {
     /// Definition sites (name → sorted name-ranges), for same-file
     /// go-to-definition. Recomputed with `import_links`.
     defs: std::collections::HashMap<String, Vec<Range<usize>>>,
+    /// Definitions found in the files THIS buffer imports (name → target file +
+    /// the name's byte range there) — resolves `obj.method()` when the method
+    /// lives with an imported class. Pushed by the app (`set_external_defs`,
+    /// computed in the background); lowest lookup priority, so local
+    /// definitions and direct import bindings always win.
+    external_defs: std::collections::HashMap<String, (std::path::PathBuf, Range<usize>)>,
     /// ⌘-click navigation (imports + definitions) for this editor's language
     /// (same push model as `errors_on`: per-pack toggle, default on).
     links_on: bool,
@@ -383,6 +401,7 @@ impl CodeEditor {
             errors_on: false,
             import_links: Vec::new(),
             import_bound: std::collections::HashMap::new(),
+            external_defs: std::collections::HashMap::new(),
             defs: std::collections::HashMap::new(),
             links_on: false,
             cmd_held: false,
@@ -450,6 +469,9 @@ impl CodeEditor {
         self.redo_stack.clear();
         self.last_edit = EditKind::Other;
         self.folded.clear();
+        // A different buffer's imported-files index would resolve names to the
+        // WRONG files — drop it; the app pushes a fresh one after opening.
+        self.external_defs.clear();
         self.recompute_folds(cx);
         cx.notify();
         cx.emit(EditorEvent::Changed);
@@ -457,6 +479,12 @@ impl CodeEditor {
 
     pub fn text(&self) -> &str {
         &self.content
+    }
+
+    /// The current import specifiers (targets), for the app's cheap "did the
+    /// import set change?" check that gates recomputing the external-defs index.
+    pub fn import_targets(&self) -> Vec<String> {
+        self.import_links.iter().map(|l| l.target.clone()).collect()
     }
 
     /// Tell the editor which scroll container currently holds it, so caret-follow and
@@ -713,7 +741,31 @@ impl CodeEditor {
                 SymbolTarget::ImportedSymbol(link.clone(), name.to_string()),
             ));
         }
+        // Lowest priority: a definition in one of the files this buffer
+        // imports (methods on imported classes land here).
+        if let Some((path, r)) = self.external_defs.get(name) {
+            return Some((word, SymbolTarget::ExternalDef(path.clone(), r.clone())));
+        }
         None
+    }
+
+    /// Test-only read view of the external index (the app never reads it back;
+    /// clicks resolve inside the editor).
+    #[cfg(test)]
+    pub fn external_def_for(&self, name: &str) -> Option<(std::path::PathBuf, Range<usize>)> {
+        self.external_defs.get(name).cloned()
+    }
+
+    /// Replace the imported-files definition index (see `external_defs`).
+    /// Pushed by the app whenever the buffer's import set resolves to a new
+    /// set of files; cleared automatically when a different file loads.
+    pub fn set_external_defs(
+        &mut self,
+        map: std::collections::HashMap<String, (std::path::PathBuf, Range<usize>)>,
+        cx: &mut Context<Self>,
+    ) {
+        self.external_defs = map;
+        cx.notify();
     }
 
     /// Recompute what the pointer sits on (from `last_mouse`), honoring the ⌘ +
@@ -1153,6 +1205,11 @@ impl CodeEditor {
                 }
                 Some((_, SymbolTarget::ImportedSymbol(link, name))) => {
                     cx.emit(EditorEvent::OpenSymbol { link, name });
+                    cx.stop_propagation();
+                    return;
+                }
+                Some((_, SymbolTarget::ExternalDef(path, range))) => {
+                    cx.emit(EditorEvent::OpenDefinition { path, range });
                     cx.stop_propagation();
                     return;
                 }

--- a/src/widgets/editor/mod.rs
+++ b/src/widgets/editor/mod.rs
@@ -119,6 +119,9 @@ pub fn bind_keys(cx: &mut App) {
 /// Emitted whenever the text changes (used by the file finder to re-query live).
 pub enum EditorEvent {
     Changed,
+    /// ⌘-click landed on an import link — the app resolves the target against
+    /// the project's file list and opens it (issue #26).
+    OpenImport(highlight::ImportLink),
 }
 
 /// A point-in-time editor state for the undo/redo stacks.
@@ -196,6 +199,18 @@ pub struct CodeEditor {
     /// opt-out). Editors nothing ever pushes to (commit box, single-line inputs,
     /// diff/merge panes) stay false.
     errors_on: bool,
+    /// Cached import links (sorted by position), recomputed with `spans` — but
+    /// ONLY when `links_on`, so editors without the toggle never pay the parse.
+    import_links: Vec<highlight::ImportLink>,
+    /// ⌘-click import navigation for this editor's language (same push model as
+    /// `errors_on`: per-pack toggle, on by default for installed packs).
+    links_on: bool,
+    /// Live ⌘-held state (tracked via `ModifiersChanged`) — gates the link hover
+    /// affordance and the click intercept.
+    cmd_held: bool,
+    /// Index into `import_links` under the pointer while ⌘ is held (drives the
+    /// underline + pointer cursor).
+    hover_link: Option<usize>,
     /// Longest line length in bytes (recomputed on content change) — drives the element's
     /// content width so long lines scroll horizontally instead of clipping.
     max_line_len: usize,
@@ -316,6 +331,10 @@ impl CodeEditor {
             spans: Vec::new(),
             error_ranges: Vec::new(),
             errors_on: false,
+            import_links: Vec::new(),
+            links_on: false,
+            cmd_held: false,
+            hover_link: None,
             max_line_len: 0,
             line_layouts: HashMap::new(),
             display_rows: 0,
@@ -470,13 +489,16 @@ impl CodeEditor {
         if self.single_line || self.content.is_empty() {
             self.spans = Vec::new();
             self.error_ranges = Vec::new();
+            self.import_links = Vec::new();
+            self.hover_link = None;
             self.foldable = Vec::new();
             self.foldable_starts.clear();
             self.max_line_len = 0;
             return;
         }
-        // Longest line (bytes) → element content width for horizontal scroll. Cheap byte
-        // scan, only on content change (not per frame).
+        self.hover_link = None; // ranges may have shifted under the pointer
+                                // Longest line (bytes) → element content width for horizontal scroll. Cheap byte
+                                // scan, only on content change (not per frame).
         self.max_line_len = self.content.split('\n').map(str::len).max().unwrap_or(0);
         // Small files: highlight + find folds inline (correct on the very first frame, no
         // flicker). Big files: clear now so the file opens instantly as plain text, then
@@ -495,6 +517,11 @@ impl CodeEditor {
             } else {
                 Vec::new()
             };
+            self.import_links = if self.links_on {
+                highlight::import_links(&self.content, self.lang)
+            } else {
+                Vec::new()
+            };
             self.foldable = highlight::fold_regions(&self.content, self.lang);
             self.foldable_starts = self.foldable.iter().map(|r| r.0).collect();
             self.folded.retain(|l| self.foldable_starts.contains(l));
@@ -502,14 +529,16 @@ impl CodeEditor {
         }
         self.spans = Vec::new();
         self.error_ranges = Vec::new();
+        self.import_links = Vec::new();
         self.foldable = Vec::new();
         self.foldable_starts.clear();
         let gen = self.compute_gen;
         let content = self.content.clone();
         let lang = self.lang;
         let errors_on = self.errors_on;
+        let links_on = self.links_on;
         cx.spawn(async move |this, cx| {
-            let (spans, foldable, errors) = cx
+            let (spans, foldable, errors, links) = cx
                 .background_executor()
                 .spawn(async move {
                     (
@@ -517,6 +546,11 @@ impl CodeEditor {
                         highlight::fold_regions(&content, lang),
                         if errors_on {
                             highlight::error_ranges(&content, lang)
+                        } else {
+                            Vec::new()
+                        },
+                        if links_on {
+                            highlight::import_links(&content, lang)
                         } else {
                             Vec::new()
                         },
@@ -528,6 +562,7 @@ impl CodeEditor {
                     // Still the current content → apply the highlight + folds.
                     ed.spans = spans;
                     ed.error_ranges = errors;
+                    ed.import_links = links;
                     ed.foldable_starts = foldable.iter().map(|r| r.0).collect();
                     ed.foldable = foldable;
                     ed.folded.retain(|l| ed.foldable_starts.contains(l));
@@ -549,6 +584,34 @@ impl CodeEditor {
         self.errors_on = on;
         self.recompute_folds(cx);
         cx.notify();
+    }
+
+    /// Toggle ⌘-click import navigation for this editor (same push model as
+    /// [`set_error_highlight`](Self::set_error_highlight): the app derives `on`
+    /// from the pack's plugins.json toggle, on by default when installed).
+    pub fn set_link_navigation(&mut self, on: bool, cx: &mut Context<Self>) {
+        if self.links_on == on {
+            return;
+        }
+        self.links_on = on;
+        self.recompute_folds(cx);
+        cx.notify();
+    }
+
+    /// Index of the import link containing byte offset `off`, if any.
+    fn link_at(&self, off: usize) -> Option<usize> {
+        self.import_links
+            .iter()
+            .position(|l| l.range.start <= off && off < l.range.end)
+    }
+
+    /// Screenshot/debug helper: force the ⌘-hover affordance on import link `i`,
+    /// as if ⌘ were held with the pointer over it (`KYDE_SHOT=imports`). Returns
+    /// whether such a link exists (false = nothing will underline).
+    pub fn force_link_hover(&mut self, i: usize) -> bool {
+        self.cmd_held = true;
+        self.hover_link = Some(i);
+        self.import_links.len() > i
     }
 
     /// (Re)start the caret blink: show it now and bump the epoch so any prior blink loop exits,
@@ -944,6 +1007,16 @@ impl CodeEditor {
         // IME text can route here incidentally while actions (cmd-z, etc.) don't dispatch.
         self.focus_handle.focus(window);
         self.restart_blink(cx);
+        // ⌘-click on an import link opens the target file (issue #26) instead of
+        // moving the caret.
+        if ev.modifiers.platform && self.links_on {
+            let off = self.offset_for_position(ev.position);
+            if let Some(i) = self.link_at(off) {
+                cx.emit(EditorEvent::OpenImport(self.import_links[i].clone()));
+                cx.stop_propagation();
+                return;
+            }
+        }
         // A click in the fold gutter toggles the fold on that display row instead
         // of moving the caret.
         if self.gutter_w > px(0.0) {
@@ -1040,6 +1113,15 @@ impl CodeEditor {
         }
     }
     fn on_mouse_move(&mut self, ev: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
+        // ⌘-hover over an import link → underline + pointer cursor (the hover
+        // clears when ⌘ lifts — see the ModifiersChanged listener).
+        if self.cmd_held && self.links_on && !self.is_selecting {
+            let hit = self.link_at(self.offset_for_position(ev.position));
+            if hit != self.hover_link {
+                self.hover_link = hit;
+                cx.notify();
+            }
+        }
         // Only extend the selection for a drag this editor itself started.
         if self.is_selecting && ev.dragging() {
             // `select_to` sets `reveal_pending`, which would yank the view back to the
@@ -1482,7 +1564,12 @@ impl Render for CodeEditor {
         div()
             .key_context(ctx.as_str())
             .track_focus(&self.focus_handle)
-            .cursor(CursorStyle::IBeam)
+            // Pointer over a ⌘-hovered import link (it's clickable); I-beam otherwise.
+            .cursor(if self.cmd_held && self.hover_link.is_some() {
+                CursorStyle::PointingHand
+            } else {
+                CursorStyle::IBeam
+            })
             .when(!fill, |d| d.w_full().min_h(relative(1.0)))
             .when(fill, gpui::Styled::size_full)
             // Transparent: the editor adopts its container's background (the rounded editor
@@ -1525,6 +1612,19 @@ impl Render for CodeEditor {
             .on_mouse_move(cx.listener(Self::on_mouse_move))
             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_mouse_up))
+            // Track ⌘ so the import-link affordance appears/disappears live.
+            .on_modifiers_changed(
+                cx.listener(|this, e: &gpui::ModifiersChangedEvent, _w, cx| {
+                    let held = e.modifiers.platform;
+                    if this.cmd_held != held {
+                        this.cmd_held = held;
+                        if !held {
+                            this.hover_link = None;
+                        }
+                        cx.notify();
+                    }
+                }),
+            )
             .child(EditorElement {
                 editor: cx.entity(),
             })
@@ -1606,12 +1706,31 @@ fn apply_error_squiggles(
     errors: &[Range<usize>],
     color: Hsla,
 ) -> Vec<TextRun> {
+    let squiggle = UnderlineStyle {
+        thickness: px(1.0),
+        color: Some(color),
+        wavy: true,
+    };
+    apply_underline_ranges(runs, line_start, line_len, errors, squiggle)
+}
+
+/// The generic run-splitter behind [`apply_error_squiggles`] (wavy, per error)
+/// and the ⌘-hover import-link underline (straight, one range): split `runs`
+/// wherever a range boundary falls in this line and set `style` on the covered
+/// pieces. `ranges` are whole-buffer byte ranges, sorted + non-overlapping.
+fn apply_underline_ranges(
+    runs: Vec<TextRun>,
+    line_start: usize,
+    line_len: usize,
+    ranges: &[Range<usize>],
+    style: UnderlineStyle,
+) -> Vec<TextRun> {
     let line_end = line_start + line_len;
-    // Binary-search the first error reaching this line (same trick as `line_runs`),
+    // Binary-search the first range reaching this line (same trick as `line_runs`),
     // then clamp the overlapping ones to line-local offsets.
-    let first = errors.partition_point(|r| r.end <= line_start);
+    let first = ranges.partition_point(|r| r.end <= line_start);
     let mut local: Vec<(usize, usize)> = Vec::new();
-    for r in &errors[first..] {
+    for r in &ranges[first..] {
         if r.start >= line_end {
             break;
         }
@@ -1623,11 +1742,6 @@ fn apply_error_squiggles(
     if local.is_empty() {
         return runs;
     }
-    let squiggle = UnderlineStyle {
-        thickness: px(1.0),
-        color: Some(color),
-        wavy: true,
-    };
     let mut out: Vec<TextRun> = Vec::with_capacity(runs.len() + local.len() * 2);
     let mut pos = 0usize; // line-local byte cursor
     let mut li = 0usize; // index into `local` (monotonic — both walks are in order)
@@ -1642,15 +1756,15 @@ fn apply_error_squiggles(
             while li < local.len() && local[li].1 <= cur {
                 li += 1;
             }
-            let (boundary, in_err) = match local.get(li) {
+            let (boundary, in_range) = match local.get(li) {
                 Some(&(es, ee)) if cur >= es => (ee.min(end), true),
                 Some(&(es, _)) => (es.min(end), false),
                 None => (end, false),
             };
             let mut piece = run.clone();
             piece.len = boundary - cur;
-            if in_err {
-                piece.underline = Some(squiggle);
+            if in_range {
+                piece.underline = Some(style);
             }
             out.push(piece);
             cur = boundary;


### PR DESCRIPTION
Closes #26.

## What
Hold ⌘ and hover an import — it underlines in the accent color and the cursor flips to a pointer; ⌘-click opens the referenced file. Per the issue: Rust, TypeScript (+TSX, and JS comes free), and Python. **On by default** for every installed pack, with a per-pack "⌘-click imports" opt-out checkbox in the plugin manager (same default-on model as error highlighting; old plugins.json reads as all-on; uninstall drops the opt-out).

## Recognized forms
- **Rust**: `mod x;` (no body → sibling file), `use` paths — plain, `as` aliases, `{…}` lists (their prefix links), `::*` wildcards. `crate::`/`super::`/`self::` resolve from src/ / the parent module / here, trying progressively shorter paths (`a::b::c` → `a/b/c.rs`, `a/b.rs`, `mod.rs` variants). External crates never resolve.
- **TS/TSX/JS**: `import … from "x"`, `export … from "x"`, `require("x")`, dynamic `import("x")`. Relative specifiers resolve with extension + index candidates (`.ts/.tsx/.js/.jsx/.mjs/.cjs/.d.ts`, `index.*`); bare specifiers are npm packages → no-op.
- **Python**: `import a.b`, `from a.b import c`, relative `from ..pkg import d` (dots walk packages up) → `x.py` or `x/__init__.py`, tried from the project root and the current dir.

## Speed cost (per the issue)
Extraction is one tree-sitter walk cached on the editor, recomputed with the syntax spans only when the pack's toggle is on — same pipeline and gating as error highlighting, per-keystroke perf guard included (`perf_import_links_large_file_stays_fast`). Hover work is a binary-search-free range probe on mouse-move while ⌘ is held; nothing runs at all with ⌘ up. Resolution runs on click only, purely against the already-cached project file list.

## UX plumbing
⌘ tracked via `on_modifiers_changed`; the hovered link underlines through the generalized run-splitter behind the error squiggles (paints inside the normal `ShapedLine` pass — virtualization free); ⌘-click emits `EditorEvent::OpenImport` instead of moving the caret. Pixel-verified the underline lands exactly under the link text. Smoke test drives resolve + open end-to-end and the npm-package no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)