### PR TITLE
feat: ⌘⌥←/⌘⌥→ back-forward file navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,6 +653,15 @@ already sorted / read-only) and re-select the sorted block. Smoke test:
 `sort_ops_rewrite_selection_and_object`. Debug shot: `KYDE_SHOT=sort-menu` +
 `KYDE_SHOT_FILE=<json>`.
 
+## Back/forward file navigation (⌘⌥← / ⌘⌥→)
+Visited-file history on `BrowseView` (`nav_history`/`nav_index`/`nav_suppress`, capped
+100): every `open_file_inner` records a visit (`nav_record` — consecutive dupes collapse;
+tab re-activation records nothing); `nav_back`/`nav_forward` walk it and reopen via the
+normal open path with `nav_suppress` on, so navigating never records; opening a NEW file
+after going back truncates the forward branch (IDE convention). Configurable actions
+`nav_back`/`nav_forward` (⌘⌥←/⌘⌥→ both presets) + ⌘⇧A palette entries; history cleared
+on project switch/close. Smoke test: `nav_back_and_forward_walk_the_visit_history`.
+
 ## Views & right-click flow (main.rs)
 Opening a project lands in **Browse (code) view**, not git — `open_project`/`new` default
 `Mode::Browse`. Git is reached on demand:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,14 +2919,14 @@ dependencies = [
 
 [[package]]
 name = "kyde-color"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "gpui",
 ]
 
 [[package]]
 name = "kyde-config"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2934,28 +2934,28 @@ dependencies = [
 
 [[package]]
 name = "kyde-diff"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "kyde-git"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kyde-markdown"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "pulldown-cmark",
 ]
 
 [[package]]
 name = "kyde-syntax"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "codebook-tree-sitter-latex",
  "kyde-color",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "kyde-theme"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "kyde-color",
  "serde",
@@ -2988,11 +2988,11 @@ dependencies = [
 
 [[package]]
 name = "kyde-tree"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "kyde-ui"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "gpui",
  "kyde-color",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "kyde-update"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/kyde-config/src/keymap.rs
+++ b/crates/kyde-config/src/keymap.rs
@@ -77,6 +77,18 @@ pub const ACTIONS: &[ActionDef] = &[
         vscode: "cmd-alt-s",
         label: "Sort Object Keys",
     },
+    ActionDef {
+        name: "nav_back",
+        webstorm: "cmd-alt-left",
+        vscode: "cmd-alt-left",
+        label: "Back (previous file)",
+    },
+    ActionDef {
+        name: "nav_forward",
+        webstorm: "cmd-alt-right",
+        vscode: "cmd-alt-right",
+        label: "Forward (next file)",
+    },
 ];
 
 /// A configurable action: its stable name, the default keystroke under each preset, and a

--- a/src/main.rs
+++ b/src/main.rs
@@ -2478,6 +2478,28 @@ fn apply_shot(view: &mut Kyde, name: &str, window: &mut Window, cx: &mut Context
                 cx.notify();
             });
         }
+        // The tab strip with more tabs than fit — the active tab must be
+        // scrolled into view (strip overflows + scrolls; regression: the bar
+        // sized itself to content and no scroll ever applied).
+        "tab-scroll" => {
+            set_packs(view, &["rust"]);
+            for f in [
+                "src/main.rs",
+                "src/app.rs",
+                "src/render.rs",
+                "src/divider.rs",
+                "src/views/browse.rs",
+                "src/views/commit.rs",
+                "src/views/diff_view.rs",
+                "src/views/history.rs",
+                "src/views/merge.rs",
+                "src/views/compare.rs",
+                "src/views/finder.rs",
+                "src/views/tabs.rs",
+            ] {
+                view.open_file(PathBuf::from(f), cx);
+            }
+        }
         // History view: the commit log for the current branch, first commit selected so the
         // changed-files list + read-only diff are populated.
         "history" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,8 @@ actions!(
         NewScratch,
         SortLines,
         SortKeys,
+        NavBack,
+        NavForward,
         EscapeKey,
         ToggleTerminal,
         NewTerminalTab,
@@ -226,6 +228,8 @@ fn apply_keymap(cx: &mut App, km: &Keymap) {
     bind_app(cx, km, "new_scratch", NewScratch);
     bind_app(cx, km, "sort_lines", SortLines);
     bind_app(cx, km, "sort_keys", SortKeys);
+    bind_app(cx, km, "nav_back", NavBack);
+    bind_app(cx, km, "nav_forward", NavForward);
     // Escape: close any open modal, else cancel the Commit view (fixed key).
     cx.bind_keys([KeyBinding::new("escape", EscapeKey, Some("Kyde"))]);
     // Backspace: delete the selected Browse-tree file/folder (fixed key). Bound to the
@@ -399,6 +403,8 @@ enum PaletteAction {
     Fonts,
     SortLines,
     SortKeys,
+    NavBack,
+    NavForward,
 }
 
 /// Action-finder entries: (label, action, keymap-action name for the shortcut
@@ -409,6 +415,12 @@ const PALETTE: &[(&str, PaletteAction, &str)] = &[
     ("Reveal in Terminal", PaletteAction::RevealInTerminal, ""),
     ("Sort Lines", PaletteAction::SortLines, "sort_lines"),
     ("Sort Object Keys", PaletteAction::SortKeys, "sort_keys"),
+    ("Back (previous file)", PaletteAction::NavBack, "nav_back"),
+    (
+        "Forward (next file)",
+        PaletteAction::NavForward,
+        "nav_forward",
+    ),
     ("Go to File", PaletteAction::GoToFile, "go_to_file"),
     ("Find in Files", PaletteAction::FindInFiles, "find_in_files"),
     ("New Scratch File", PaletteAction::NewScratch, "new_scratch"),
@@ -898,6 +910,13 @@ struct BrowseView {
     /// Cmd-clicked FILE rows (ordered). Exactly two → the right-click menu
     /// offers "Compare Selected" (issue #42). Cleared by any plain click.
     multi_selected: Vec<PathBuf>,
+    /// Visited-file history for ⌘⌥←/⌘⌥→ back/forward navigation.
+    nav_history: Vec<PathBuf>,
+    /// Current position in `nav_history` (points at the open file's entry).
+    nav_index: usize,
+    /// True while back/forward itself opens a file, so the open doesn't record
+    /// a new history entry (which would truncate the forward branch).
+    nav_suppress: bool,
     /// Import targets the external-defs index was last computed for — the
     /// cheap change gate (recompute only when the buffer's import set changes).
     ext_defs_targets: Vec<String>,
@@ -972,6 +991,9 @@ impl BrowseView {
             tab_scroll: ScrollHandle::new(),
             selected_path: None,
             multi_selected: Vec::new(),
+            nav_history: Vec::new(),
+            nav_index: 0,
+            nav_suppress: false,
             ext_defs_targets: Vec::new(),
             ext_defs_gen: 0,
             tree_scroll: ScrollHandle::new(),
@@ -3186,6 +3208,41 @@ mod gpui_smoke_tests {
                 assert_eq!(k.browse.open_path, Some(PathBuf::from("lib.ts")));
                 let sel = k.browse.editor.read(cx).selection();
                 assert_eq!(&lib[sel], "meow", "selection lands on the method");
+            })
+            .unwrap();
+    }
+
+    /// ⌘⌥←/⌘⌥→ file navigation: visits record, back/forward walk them without
+    /// recording, and opening a new file after going back discards the forward
+    /// branch.
+    #[gpui::test]
+    fn nav_back_and_forward_walk_the_visit_history(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        for n in ["a.txt", "b.txt", "c.txt"] {
+            std::fs::write(dir.join(n), n).unwrap();
+        }
+        handle.update(cx, |k, _w, cx| k.refresh(cx)).unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, cx| {
+                for n in ["a.txt", "b.txt", "c.txt"] {
+                    k.open_file(PathBuf::from(n), cx);
+                }
+                k.nav_back(cx);
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("b.txt")));
+                k.nav_back(cx);
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("a.txt")));
+                k.nav_back(cx); // start of history — no-op
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("a.txt")));
+                k.nav_forward(cx);
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("b.txt")));
+                // New open from the middle discards the forward branch (c.txt).
+                k.open_file(PathBuf::from("app.tsx"), cx);
+                k.nav_forward(cx); // nothing forward anymore
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("app.tsx")));
+                k.nav_back(cx);
+                assert_eq!(k.browse.open_path, Some(PathBuf::from("b.txt")));
+                assert_eq!(k.browse.nav_history.len(), 3, "a, b, app.tsx (c discarded)");
             })
             .unwrap();
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -308,6 +308,8 @@ impl Render for Kyde {
             .on_action(cx.listener(Self::act_mode_browse))
             .on_action(cx.listener(Self::act_sort_lines))
             .on_action(cx.listener(Self::act_sort_keys))
+            .on_action(cx.listener(Self::act_nav_back))
+            .on_action(cx.listener(Self::act_nav_forward))
             .on_action(cx.listener(Self::open_keymap))
             .on_action(cx.listener(Self::open_recent_project))
             .on_action(cx.listener(Self::act_open_project))

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -290,7 +290,7 @@ impl Kyde {
                 // edge — which is exactly where the tab-bar's trailing controls live, so the
                 // `▾` overflow button vanished once tabs/content got wide.
                 .min_w_0()
-                .child(self.render_tab_bar(ui, fs, cx));
+                .child(self.render_tab_bar(ui, fs, self.editor_island_w(window), cx));
             // Install banner only applies to text/code files, not image previews.
             if image.is_none() {
                 // Unresolved-conflict banner first — resolving beats installing a grammar.
@@ -907,6 +907,28 @@ impl Kyde {
             .and_then(|p| self.browse.open_tabs.iter().position(|t| t == p))
         {
             self.browse.tab_scroll.scroll_to_item(i);
+            // Re-issue once shortly after: a scroll requested BEFORE the strip's
+            // first paint (session restore, burst opens) gets consumed by gpui
+            // against a zeroed container-bounds snapshot and lands at offset 0.
+            // By the retry the strip has painted, so the request applies for real.
+            cx.spawn(async move |this, cx| {
+                cx.background_executor()
+                    .timer(std::time::Duration::from_millis(60))
+                    .await;
+                this.update(cx, |k, cx| {
+                    let active = k
+                        .browse
+                        .open_path
+                        .as_ref()
+                        .and_then(|p| k.browse.open_tabs.iter().position(|t| t == p));
+                    if let Some(i) = active {
+                        k.browse.tab_scroll.scroll_to_item(i);
+                        cx.notify();
+                    }
+                })
+                .ok();
+            })
+            .detach();
         }
         self.load_font_preview(cx);
     }

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -831,6 +831,7 @@ impl Kyde {
     }
 
     fn open_file_inner(&mut self, rel: PathBuf, preview: bool, cx: &mut Context<Self>) {
+        self.nav_record(&rel);
         // Images preview via `img()` and font files preview in their own typeface (see
         // render_browse) — don't load their binary bytes into the text editor.
         if !is_image(&rel) && !is_font_file(&rel) {
@@ -1021,6 +1022,77 @@ impl Kyde {
         cx: &mut Context<Self>,
     ) {
         self.sort_object_keys_at_caret(cx);
+    }
+
+    // ── back/forward file navigation (⌘⌥← / ⌘⌥→) ─────────────────
+    /// Record a visit in the file-navigation history. Opening a new file after
+    /// going back discards the forward branch (the IDE convention); navigating
+    /// via back/forward itself records nothing (`nav_suppress`). Consecutive
+    /// duplicates collapse; capped at 100 entries.
+    fn nav_record(&mut self, rel: &PathBuf) {
+        if self.browse.nav_suppress {
+            return;
+        }
+        let h = &mut self.browse.nav_history;
+        if h.get(self.browse.nav_index) == Some(rel) {
+            return; // re-activating the current file (tab click) — no new entry
+        }
+        h.truncate(self.browse.nav_index.saturating_add(1).min(h.len()));
+        h.push(rel.clone());
+        if h.len() > 100 {
+            h.remove(0);
+        }
+        self.browse.nav_index = h.len() - 1;
+    }
+
+    /// ⌘⌥← — reopen the previously visited file (no-op at the start of history).
+    pub(crate) fn nav_back(&mut self, cx: &mut Context<Self>) {
+        if self.browse.nav_index == 0 {
+            return;
+        }
+        self.browse.nav_index -= 1;
+        self.nav_open_current(cx);
+    }
+
+    /// ⌘⌥→ — reopen the next file (no-op at the end of history).
+    pub(crate) fn nav_forward(&mut self, cx: &mut Context<Self>) {
+        if self.browse.nav_index + 1 >= self.browse.nav_history.len() {
+            return;
+        }
+        self.browse.nav_index += 1;
+        self.nav_open_current(cx);
+    }
+
+    /// Open the history entry at `nav_index` without recording a new visit.
+    /// A file deleted since it was visited just refreshes empty-ish via the
+    /// normal open path (never an error).
+    fn nav_open_current(&mut self, cx: &mut Context<Self>) {
+        let Some(rel) = self.browse.nav_history.get(self.browse.nav_index).cloned() else {
+            return;
+        };
+        self.mode = Mode::Browse;
+        self.browse.nav_suppress = true;
+        self.open_file(rel, cx);
+        self.browse.nav_suppress = false;
+        cx.notify();
+    }
+
+    pub(crate) fn act_nav_back(
+        &mut self,
+        _: &NavBack,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.nav_back(cx);
+    }
+
+    pub(crate) fn act_nav_forward(
+        &mut self,
+        _: &NavForward,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.nav_forward(cx);
     }
 
     // ── ⌘-click import navigation (issue #26) ─────────────────────

--- a/src/views/finder.rs
+++ b/src/views/finder.rs
@@ -550,6 +550,14 @@ impl Kyde {
                 window.focus(&self.focus_handle);
                 self.sort_object_keys_at_caret(cx);
             }
+            PaletteAction::NavBack => {
+                window.focus(&self.focus_handle);
+                self.nav_back(cx);
+            }
+            PaletteAction::NavForward => {
+                window.focus(&self.focus_handle);
+                self.nav_forward(cx);
+            }
         }
     }
 

--- a/src/views/projects_view.rs
+++ b/src/views/projects_view.rs
@@ -516,6 +516,8 @@ impl Kyde {
             self.browse.open_tabs.clear();
             self.browse.preview_tab = None;
             self.browse.multi_selected.clear();
+            self.browse.nav_history.clear();
+            self.browse.nav_index = 0;
             self.selected = None;
             self.browse.expanded.clear();
             self.browse.expanded.insert(PathBuf::new()); // root folder visible by default
@@ -543,6 +545,8 @@ impl Kyde {
             self.browse.open_tabs.clear();
             self.browse.preview_tab = None;
             self.browse.multi_selected.clear();
+            self.browse.nav_history.clear();
+            self.browse.nav_index = 0;
             self.selected = None;
         } else {
             // Prefer the tab that shifted into this slot, else the previous one.

--- a/src/views/tabs.rs
+++ b/src/views/tabs.rs
@@ -11,6 +11,7 @@ impl Kyde {
         &self,
         ui: &'static str,
         fs: gpui::Pixels,
+        island_w: f32,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let t = theme::get();
@@ -122,6 +123,17 @@ impl Kyde {
             .flex_row()
             .items_center()
             .flex_none()
+            // Pin the bar to the ISLAND's measured width (the editor-scrollbar
+            // trick). Flex alone (`w_full`/`flex_1`/`min_w_0` up the chain)
+            // never constrained it: taffy sizes the bar to its tab content
+            // (diagnosed 1633px in a 1280px window; the island merely clips
+            // it), so the inner overflow_x_scroll never actually overflows,
+            // max_offset stays 0, and every scroll — wheel or scroll_to_item —
+            // is clamped back to zero. An explicit width makes the scroll
+            // container viewport-sized, which is what makes tab scrolling
+            // (and scroll-active-tab-into-view) work at all.
+            .w(px(island_w))
+            .min_w_0()
             .h(px(38.0))
             .bg(t.panel_bg)
             // Match the editor island's top corners (gpui clips rectangular, so the


### PR DESCRIPTION
Closes #53.

Visited-file history for the Browse view, IDE-style:

- Every file open records a visit (consecutive duplicates collapse; clicking the already-active tab records nothing). Capped at 100.
- **⌘⌥←** walks back, **⌘⌥→** forward — both reopen through the normal open path without recording, so navigating never mutates the history you're walking.
- Opening a new file after going back **discards the forward branch** (the convention in every IDE).
- Configurable keymap actions (`nav_back` / `nav_forward`, same chords both presets — free in the existing map) + ⌘⇧A palette entries ("Back (previous file)" / "Forward (next file)").
- History clears on project switch/close.

Smoke test walks the full semantics: record → back ×2 → boundary no-op → forward → branch-discard on a new open.

(Cherry-picked onto main — the commit originally landed on the #52 branch after that PR merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)