### PR TITLE
fix: rollback of added files, finder git-status colors, cmd+backspace delete

### DIFF
--- a/crates/kyde-git/src/lib.rs
+++ b/crates/kyde-git/src/lib.rs
@@ -387,23 +387,22 @@ impl Repo {
         ) {
             Ok(_) => Ok(()),
             // A repo with no commits yet (unborn HEAD): `restore --staged` needs HEAD to
-            // restore FROM and dies with "could not resolve HEAD". Everything staged there
-            // is by definition newly added, so dropping the index entry — keeping the
+            // restore FROM and dies with "could not resolve HEAD" (newer gits quote it:
+            // "could not resolve 'HEAD'" — match the stable prefix only). Everything staged
+            // there is by definition newly added, so dropping the index entry — keeping the
             // working-tree file — is the exact same unstage.
-            Err(GitError::Command { stderr, .. }) if stderr.contains("could not resolve HEAD") => {
-                git(
-                    &self.root,
-                    &[
-                        "rm",
-                        "--cached",
-                        "--force",
-                        "--quiet",
-                        "--",
-                        &rel.to_string_lossy(),
-                    ],
-                )
-                .map(|_| ())
-            }
+            Err(GitError::Command { stderr, .. }) if stderr.contains("could not resolve") => git(
+                &self.root,
+                &[
+                    "rm",
+                    "--cached",
+                    "--force",
+                    "--quiet",
+                    "--",
+                    &rel.to_string_lossy(),
+                ],
+            )
+            .map(|_| ()),
             Err(e) => Err(e),
         }
     }

--- a/crates/kyde-git/src/lib.rs
+++ b/crates/kyde-git/src/lib.rs
@@ -381,11 +381,31 @@ impl Repo {
 
     /// Unstage a file (`git restore --staged -- <rel>`).
     pub fn unstage(&self, rel: &Path) -> Result<()> {
-        git(
+        match git(
             &self.root,
             &["restore", "--staged", "--", &rel.to_string_lossy()],
-        )
-        .map(|_| ())
+        ) {
+            Ok(_) => Ok(()),
+            // A repo with no commits yet (unborn HEAD): `restore --staged` needs HEAD to
+            // restore FROM and dies with "could not resolve HEAD". Everything staged there
+            // is by definition newly added, so dropping the index entry — keeping the
+            // working-tree file — is the exact same unstage.
+            Err(GitError::Command { stderr, .. }) if stderr.contains("could not resolve HEAD") => {
+                git(
+                    &self.root,
+                    &[
+                        "rm",
+                        "--cached",
+                        "--force",
+                        "--quiet",
+                        "--",
+                        &rel.to_string_lossy(),
+                    ],
+                )
+                .map(|_| ())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Discard all changes to a tracked file (index + worktree → HEAD).
@@ -1571,6 +1591,50 @@ mod tests {
         let files = repo.push_files();
         assert_eq!(files.len(), 1, "only the new commit's file is unpushed");
         assert_eq!(files[0].path, PathBuf::from("b.txt"));
+
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    /// `unstage` on a newly-added file must drop it back to untracked — both in a normal
+    /// repo (`restore --staged`) and on an unborn HEAD, where `restore --staged` can't
+    /// resolve HEAD and the `git rm --cached` fallback must kick in (issue #59).
+    #[test]
+    fn unstage_added_file_works_with_and_without_head() {
+        use std::fs;
+        let g = |dir: &Path, args: &[&str]| {
+            git(dir, args).unwrap_or_else(|e| panic!("git {args:?} failed: {e}"))
+        };
+        let base = std::env::temp_dir().join(format!("kyde-unstage-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        g(&base, &["init", "-b", "main"]);
+        g(&base, &["config", "user.email", "t@example.com"]);
+        g(&base, &["config", "user.name", "Test"]);
+        g(&base, &["config", "commit.gpgsign", "false"]);
+        let repo = Repo::discover(&base).unwrap();
+
+        // Unborn HEAD: no commits yet, stage a new file, unstage it.
+        fs::write(base.join("first.txt"), "1\n").unwrap();
+        repo.stage(Path::new("first.txt")).unwrap();
+        assert_eq!(repo.status().unwrap()[0].status, FileStatus::Added);
+        repo.unstage(Path::new("first.txt"))
+            .expect("unstage must survive an unborn HEAD");
+        let st = repo.status().unwrap();
+        assert_eq!(st.len(), 1);
+        assert_eq!(st[0].status, FileStatus::Untracked, "back to untracked");
+        assert!(base.join("first.txt").exists(), "working copy untouched");
+
+        // Normal repo (HEAD exists): same flow through `restore --staged`.
+        g(&base, &["add", "-A"]);
+        g(&base, &["commit", "-m", "init"]);
+        fs::write(base.join("second.txt"), "2\n").unwrap();
+        repo.stage(Path::new("second.txt")).unwrap();
+        assert_eq!(repo.status().unwrap()[0].status, FileStatus::Added);
+        repo.unstage(Path::new("second.txt")).unwrap();
+        let st = repo.status().unwrap();
+        assert_eq!(st.len(), 1);
+        assert_eq!(st[0].status, FileStatus::Untracked);
+        assert!(base.join("second.txt").exists());
 
         let _ = fs::remove_dir_all(&base);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,13 @@ fn apply_keymap(cx: &mut App, km: &Keymap) {
     // Backspace: delete the selected Browse-tree file/folder (fixed key). Bound to the
     // "Kyde" context, NOT globally, so the deeper editor/commit-box/terminal Backspace
     // bindings win whenever one of those is focused — this only fires at the app root.
-    cx.bind_keys([KeyBinding::new("backspace", DeleteFile, Some("Kyde"))]);
+    // ⌘⌫ deletes too (issue #61 — Finder's delete shortcut; muscle memory says both work).
+    // Safe at the root: the editor binds cmd-backspace to DeleteToHome in its own deeper
+    // context, so this only fires when no editor/terminal is focused.
+    cx.bind_keys([
+        KeyBinding::new("backspace", DeleteFile, Some("Kyde")),
+        KeyBinding::new("cmd-backspace", DeleteFile, Some("Kyde")),
+    ]);
     // Jump between diff changes (Alt+↓ / Alt+↑). Global so they fire while the diff editor is
     // focused; no-op when no diff is showing.
     cx.bind_keys([
@@ -265,6 +271,9 @@ fn apply_keymap(cx: &mut App, km: &Keymap) {
         // (on TerminalView) write the raw byte to the shell, exactly like the editor binds
         // backspace to its own buffer action. The "Terminal" context (depth) shadows "Kyde".
         KeyBinding::new("backspace", TerminalBackspace, Some("Terminal")),
+        // ⌘⌫ is DeleteFile in "Kyde" (issue #61); in the terminal it must act as a plain
+        // backspace, not delete the tree-selected file out from under a typing user.
+        KeyBinding::new("cmd-backspace", TerminalBackspace, Some("Terminal")),
         KeyBinding::new("escape", TerminalEscape, Some("Terminal")),
     ]);
     // In-editor find / replace (fixed keys).
@@ -3509,8 +3518,15 @@ mod gpui_smoke_tests {
         handle
             .update(cx, |k, _w, _cx| assert!(k.rollback_win.is_some()))
             .unwrap();
-        // Simulate the Rollback button.
-        handle.update(cx, |k, _w, cx| k.do_rollback(cx)).unwrap();
+        // Simulate the Rollback button, with "delete local copies" UNticked — the untracked
+        // file must survive on disk (the pre-checked default is covered by
+        // `rollback_deletes_newly_added_files`).
+        handle
+            .update(cx, |k, _w, cx| {
+                k.rollback_delete_added = false;
+                k.do_rollback(cx);
+            })
+            .unwrap();
         cx.run_until_parked(); // let the deferred remove_window run
         handle
             .update(cx, |k, _w, _cx| {
@@ -3519,6 +3535,48 @@ mod gpui_smoke_tests {
                 assert!(
                     !k.files.iter().any(|f| f.path.ends_with("app.tsx")),
                     "the modified file should have been rolled back"
+                );
+            })
+            .unwrap();
+    }
+
+    /// Rolling back a newly `git add`ed file must actually remove it (issue #59): the
+    /// delete-local-copies toggle is pre-checked, so the default rollback unstages the
+    /// Added file AND deletes it — instead of leaving it untracked (same green, still in
+    /// the changes list) which read as "rollback did nothing".
+    #[gpui::test]
+    fn rollback_deletes_newly_added_files(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        // Stage the new file so it shows as Added, and pick up the new status.
+        git(&dir, &["add", "new.txt"]);
+        handle.update(cx, |k, _w, cx| k.refresh(cx)).unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, cx| {
+                assert!(
+                    k.files
+                        .iter()
+                        .any(|f| f.path.ends_with("new.txt") && f.status == FileStatus::Added),
+                    "staged new file should be Added"
+                );
+                k.open_rollback_path(PathBuf::from("new.txt"), cx);
+                assert!(
+                    k.rollback_delete_added,
+                    "delete-local-copies defaults to checked"
+                );
+                k.do_rollback(cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, _cx| {
+                assert!(
+                    !dir.join("new.txt").exists(),
+                    "the added file is deleted from disk"
+                );
+                assert!(
+                    !k.files.iter().any(|f| f.path.ends_with("new.txt")),
+                    "the added file left the changes list"
                 );
             })
             .unwrap();

--- a/src/views/finder.rs
+++ b/src/views/finder.rs
@@ -27,6 +27,10 @@ impl Kyde {
                 .py_1()
                 .text_color(t.text)
         };
+        // Color changed files by their git status, matching the Browse tree / commit view
+        // (issue #60). O(1) lookup per row — same map the tree builds per frame.
+        let status_by_path: std::collections::HashMap<&PathBuf, FileStatus> =
+            self.files.iter().map(|f| (&f.path, f.status)).collect();
         let rows: Vec<gpui::AnyElement> = match self.finder.mode {
             FinderMode::Files => self
                 .finder
@@ -36,6 +40,7 @@ impl Kyde {
                 .map(|(i, p)| {
                     let sel = i == self.finder.selected;
                     let name: SharedString = p.to_string_lossy().into_owned().into();
+                    let name_color = status_by_path.get(p).map_or(t.text, |&s| status_color(s));
                     let pc = p.clone();
                     let icon = div()
                         .w(px(20.0))
@@ -48,7 +53,13 @@ impl Kyde {
                         .child(badge_inner(file_badge(p), 0.0));
                     row_base(i, sel)
                         .child(icon)
-                        .child(div().min_w_0().truncate().child(name))
+                        .child(
+                            div()
+                                .min_w_0()
+                                .truncate()
+                                .text_color(name_color)
+                                .child(name),
+                        )
                         .on_mouse_down(
                             MouseButton::Left,
                             cx.listener(move |this, _e, window, cx| {

--- a/src/views/rollback.rs
+++ b/src/views/rollback.rs
@@ -213,7 +213,11 @@ impl Kyde {
             return;
         }
         self.rollback_checked = checked;
-        self.rollback_delete_added = false;
+        // Pre-checked (IntelliJ default): rolling back a newly-added file should return to
+        // the pre-change state — the file GONE, not merely unstaged. Unstage-only leaves it
+        // untracked, which renders the same green and still sits in the changes list, so the
+        // rollback looks like a no-op (issue #59). Unticking keeps local copies.
+        self.rollback_delete_added = true;
         self.open_modal_window(ModalKind::Rollback, "Rollback Changes", 560.0, 640.0, cx);
         cx.notify();
     }


### PR DESCRIPTION
Fixes three bugs in one pass:

## #59 — can't rollback newly added files
- The "Delete local copies of added files" toggle is now **pre-checked** (IntelliJ default). Rolling back an Added file previously only unstaged it — the file stayed on disk as untracked, rendered the *same green*, and still sat in the changes list, so the rollback read as a no-op. Default rollback now returns to the true pre-change state (file gone); unticking keeps local copies.
- `Repo::unstage` now survives an **unborn HEAD** (repo with no commits): `git restore --staged` dies with "could not resolve HEAD" there, so it falls back to `git rm --cached --force` (identical semantics — everything staged pre-first-commit is newly added).

## #60 — finder filenames don't reflect git status
⌘P file-finder rows now color changed files by their git status via the same `status_color` map the Browse tree and commit view use.

## #61 — cmd+backspace should delete like backspace
`cmd-backspace` bound to `DeleteFile` in the "Kyde" context alongside plain `backspace`. Shadowed in the "Terminal" context (acts as plain backspace) so a typing user can't delete the tree-selected file; the editor's own deeper `cmd-backspace` (DeleteToHome) still wins when an editor is focused.

## Tests
- `kyde-git::unstage_added_file_works_with_and_without_head` — unstage on unborn HEAD (fallback path) and normal HEAD.
- smoke `rollback_deletes_newly_added_files` — stage a new file, rollback with the default toggle → file removed from disk + changes list.
- smoke `rollback_action_closes_window` updated to cover the unticked path (untracked file survives).

`cargo fmt` + `clippy --workspace --all-targets --all-features -D warnings` + `cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)