### PR TITLE
feat: file-tree cut/copy/paste, drag & drop, folder rename, non-git guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,14 +2970,14 @@ dependencies = [
 
 [[package]]
 name = "kyde-color"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "gpui",
 ]
 
 [[package]]
 name = "kyde-config"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2985,21 +2985,21 @@ dependencies = [
 
 [[package]]
 name = "kyde-diff"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "kyde-git"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "kyde-local-history"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3009,14 +3009,14 @@ dependencies = [
 
 [[package]]
 name = "kyde-markdown"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "pulldown-cmark",
 ]
 
 [[package]]
 name = "kyde-syntax"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "codebook-tree-sitter-latex",
  "kyde-color",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "kyde-theme"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "kyde-color",
  "serde",
@@ -3049,11 +3049,11 @@ dependencies = [
 
 [[package]]
 name = "kyde-tree"
-version = "2.3.0"
+version = "2.4.0"
 
 [[package]]
 name = "kyde-ui"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "gpui",
  "kyde-color",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "kyde-update"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "serde_json",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,20 @@ alacritty_terminal = { version = "0.26.0", optional = true }
 # gpui's own objc2 deps so the ABI lines up.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2.workspace = true
-objc2-foundation = { workspace = true, features = ["NSData", "NSProcessInfo"] }
-objc2-app-kit = { workspace = true, features = ["NSApplication", "NSImage", "NSResponder"] }
+objc2-foundation = { workspace = true, features = [
+    "NSData",
+    "NSProcessInfo",
+    "NSString",
+    "NSArray",
+    "NSURL",
+] }
+objc2-app-kit = { workspace = true, features = [
+    "NSApplication",
+    "NSImage",
+    "NSResponder",
+    "NSPasteboard",
+    "NSPasteboardItem",
+] }
 
 # Embeds the app icon + version into kyde.exe at build time (see build.rs).
 # Windows-only; nothing to compile on macOS/Linux.

--- a/assets/icons/clipboard.svg
+++ b/assets/icons/clipboard.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
+</svg>

--- a/assets/icons/copy.svg
+++ b/assets/icons/copy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+</svg>

--- a/assets/icons/scissors.svg
+++ b/assets/icons/scissors.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/>
+</svg>

--- a/crates/kyde-git/src/lib.rs
+++ b/crates/kyde-git/src/lib.rs
@@ -182,6 +182,14 @@ impl Repo {
         Ok(Self { root })
     }
 
+    /// Initialise a new git repository at `path` (`git init`) and return it opened.
+    /// Errors if `path` isn't a directory or `git init` fails.
+    pub fn init(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        git(path, &["init"])?;
+        Self::discover(path)
+    }
+
     /// The repository's working-tree root.
     pub fn root(&self) -> &Path {
         &self.root
@@ -1101,6 +1109,23 @@ fn git_stdin(dir: &Path, args: &[&str], stdin: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn init_turns_a_plain_dir_into_a_repo() {
+        let dir = std::env::temp_dir().join(format!("kyde-git-init-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Not a repo yet.
+        assert!(Repo::discover(&dir).is_err());
+        // init makes it one, rooted at the dir.
+        let repo = Repo::init(&dir).unwrap();
+        assert!(dir.join(".git").exists());
+        assert_eq!(
+            repo.root().canonicalize().unwrap(),
+            dir.canonicalize().unwrap()
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn push_rejected_matches_only_non_fast_forward() {

--- a/crates/kyde-ui/src/lib.rs
+++ b/crates/kyde-ui/src/lib.rs
@@ -9,6 +9,7 @@ mod checkbox;
 mod color;
 mod footer;
 mod menu;
+mod panel;
 /// Shared list-picker mechanics (bounded nav + the selected/hover row pill). Call sites
 /// use the explicit `ui::picker::…`.
 pub mod picker;
@@ -25,6 +26,7 @@ pub use checkbox::*;
 pub use color::*;
 pub use footer::*;
 pub use menu::*;
+pub use panel::*;
 pub use scrollbar::*;
 pub use select::*;
 pub use stats::*;

--- a/crates/kyde-ui/src/menu.rs
+++ b/crates/kyde-ui/src/menu.rs
@@ -1,5 +1,15 @@
 //! Context-menu row icon, keyed off the row label (so call sites stay `item("…")`).
 
+use gpui::prelude::*;
+use gpui::{div, px, Div};
+use kyde_theme as theme;
+
+/// A subtle full-width separator between context-menu groups (a hairline in the divider
+/// colour with a little vertical breathing room). Chain nothing — just `.child(menu_divider())`.
+pub fn menu_divider() -> Div {
+    div().h(px(1.0)).my_1().mx_2().bg(theme::get().divider)
+}
+
 /// Icon path for a context-menu row. Tolerates a leading "✓ " and trailing "…". `None` → no
 /// icon (still reserves the slot so labels line up).
 pub fn menu_icon(label: &str) -> Option<&'static str> {
@@ -17,6 +27,10 @@ pub fn menu_icon(label: &str) -> Option<&'static str> {
         "Directory" => "icons/folder.svg",
         "Rename" => "icons/pencil.svg",
         "Delete" => "icons/trash.svg",
+        "Cut" => "icons/scissors.svg",
+        "Copy" => "icons/copy.svg",
+        "Paste" => "icons/clipboard.svg",
+        "Local History" => "icons/file-clock.svg",
         "Git History" => "icons/history.svg",
         "Reveal in Finder" => "icons/folder.svg",
         "View Diff" | "Show Diff" => "icons/file-lines.svg",

--- a/crates/kyde-ui/src/panel.rs
+++ b/crates/kyde-ui/src/panel.rs
@@ -1,0 +1,82 @@
+//! Shared modal/dialog panel scaffolding — the chrome + text rows that every confirm
+//! dialog, prompt, and empty-state island repeated by hand (issue #64). Like `btn_*` and
+//! `modal_footer`, callers chain their own children (title/body/footer, inputs, buttons).
+
+use gpui::prelude::*;
+use gpui::{div, px, Div, SharedString};
+use kyde_theme as theme;
+
+/// Overlay confirm/prompt panel chrome (delete confirm, rename prompt): a fixed-width
+/// rounded island on `frame_bg` with a divider border + shadow, UI font, one-step-larger
+/// text, and `occlude`d so clicks don't bleed through. Chain [`dialog_title`] /
+/// [`dialog_body`] / [`crate::modal_footer`] as children (and any `key_context`/`on_action`).
+pub fn modal_panel(width: f32, ui: &'static str) -> Div {
+    let t = theme::get();
+    div()
+        .w(px(width))
+        .flex()
+        .flex_col()
+        .gap_3()
+        .p_4()
+        .bg(t.frame_bg)
+        .border_1()
+        .border_color(t.divider)
+        .rounded(px(theme::ISLAND_RADIUS))
+        .shadow_lg()
+        .font_family(ui)
+        .text_size(px(t.ui_font_size + 1.0))
+        .occlude()
+}
+
+/// A dialog's title line (primary text color). Font size is inherited from the panel.
+pub fn dialog_title(title: impl Into<SharedString>) -> Div {
+    div().text_color(theme::get().text).child(title.into())
+}
+
+/// A dialog's muted body paragraph: `flex_1` (grows to push a footer to the bottom) +
+/// `secondary_text` at the base UI size. For the wrap-and-fill descriptions in confirm
+/// dialogs (delete, clear data, clear local history).
+pub fn dialog_body(text: impl Into<SharedString>) -> Div {
+    let t = theme::get();
+    div()
+        .flex_1()
+        .text_color(t.secondary_text)
+        .text_size(px(t.ui_font_size))
+        .child(text.into())
+}
+
+/// The body of a native modal *window* confirm dialog (Clear Data, Clear Local History):
+/// a `size_full` column of [`dialog_title`] + [`dialog_body`]. The window itself provides
+/// the chrome + titlebar; chain [`crate::modal_footer`] (Cancel + primary) as the last child.
+pub fn confirm_body(title: impl Into<SharedString>, description: impl Into<SharedString>) -> Div {
+    let t = theme::get();
+    div()
+        .size_full()
+        .flex()
+        .flex_col()
+        .gap_3()
+        .p_4()
+        .font_family(theme::font::UI_FAMILY)
+        .text_size(px(t.ui_font_size + 1.0))
+        .child(dialog_title(title))
+        .child(dialog_body(description))
+}
+
+/// A centered empty-state island (e.g. "You have nothing to commit", "Select a file"): the
+/// panel fills its slot on `main_bg`, rounded like the other islands, with the muted
+/// `line_number` message centered. Chain extra children (icon, button) for richer states.
+pub fn empty_state(message: impl Into<SharedString>, ui: &'static str) -> Div {
+    let t = theme::get();
+    div()
+        .flex()
+        .flex_1()
+        .h_full()
+        .items_center()
+        .justify_center()
+        .bg(t.main_bg)
+        .rounded(px(theme::ISLAND_RADIUS))
+        .font_family(ui)
+        .text_size(px(t.ui_font_size + 1.0))
+        .text_color(t.line_number)
+        .child(message.into())
+}

--- a/crates/kyde-ui/src/tree.rs
+++ b/crates/kyde-ui/src/tree.rs
@@ -7,6 +7,41 @@ use gpui::prelude::*;
 use gpui::{div, px, svg, Context, MouseButton, Pixels, SharedString, Window};
 use kyde_theme as theme;
 
+/// Drag payload for a tree row: the path being moved. Drop targets type-match on this, so
+/// an in-app row drag never collides with an OS file drop (`ExternalPaths`).
+#[derive(Clone)]
+pub struct DragPath(pub std::path::PathBuf);
+
+/// The little chip that follows the cursor while a tree row is dragged.
+pub struct DragPreview {
+    name: SharedString,
+}
+
+impl gpui::Render for DragPreview {
+    fn render(&mut self, _w: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let t = theme::get();
+        div()
+            .px_2()
+            .py_0p5()
+            .rounded_md()
+            .bg(t.bg_light)
+            .border_1()
+            .border_color(t.divider)
+            .text_color(t.text)
+            .text_size(px(theme::get().ui_font_size + 1.0))
+            .font_family(theme::font::UI_FAMILY)
+            .child(self.name.clone())
+    }
+}
+
+/// Boxed drop handler: `(view, dragged_source_path, cx)`. Passed to [`item`] on rows that
+/// accept a drop (directories); `None` means the row is not a drop target.
+pub type OnDrop<V> = Box<dyn Fn(&mut V, std::path::PathBuf, &mut Context<V>)>;
+
+/// Boxed handler for files dragged in from the OS file manager (Finder): `(view, paths,
+/// cx)`. `Some` on a row makes it a target for external-file drops with a highlight.
+pub type OnExtDrop<V> = Box<dyn Fn(&mut V, Vec<std::path::PathBuf>, &mut Context<V>)>;
+
 /// Render one file-tree row (chevron + icon + label) generic over the hosting view `V`.
 /// The caller supplies the row's data + click/right-click handlers; this owns the layout,
 /// indentation, and hover/selected styling so every tree in the app looks identical.
@@ -23,6 +58,12 @@ pub fn item<V: 'static>(
     name_color: kyde_color::Color,
     checkbox: Option<bool>,
     trailing: Option<gpui::AnyElement>,
+    // `draggable` makes the row a drag source (payload = its own `path`); `on_drop` = Some
+    // makes it a target for in-app row drags (issue #65); `on_ext_drop` = Some makes it a
+    // target for OS file-manager drops (issue #67). All default off.
+    draggable: bool,
+    on_drop: Option<OnDrop<V>>,
+    on_ext_drop: Option<OnExtDrop<V>>,
     on_activate: impl Fn(&mut V, &gpui::MouseDownEvent, &mut Window, &mut Context<V>) + 'static,
     on_check: impl Fn(&mut V, &mut Context<V>) + 'static,
     on_context: impl Fn(&mut V, gpui::Point<Pixels>, &mut Context<V>) + 'static,
@@ -108,7 +149,20 @@ pub fn item<V: 'static>(
         )
         .when_some(trailing, gpui::ParentElement::child);
 
-    div()
+    // A stable per-path id makes the row a stateful element (needed for drag), and a Copy
+    // color to tint the row while a compatible drag hovers it.
+    let row_id: gpui::ElementId =
+        SharedString::from(format!("tree-row::{}", path.to_string_lossy())).into();
+    let drop_hl = t.selected_bg;
+    let drag_name: SharedString = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+        .into();
+    let drag_src = path.to_path_buf();
+
+    let mut row = div()
+        .id(row_id)
         .flex()
         .flex_row()
         .items_center()
@@ -133,6 +187,30 @@ pub fn item<V: 'static>(
             cx.listener(move |this, e: &gpui::MouseDownEvent, _w, cx| {
                 on_context(this, e.position, cx);
             }),
-        )
-        .into_any_element()
+        );
+
+    if draggable {
+        row = row.on_drag(DragPath(drag_src), move |_p, _off, _w, cx| {
+            cx.new(|_| DragPreview {
+                name: drag_name.clone(),
+            })
+        });
+    }
+    if let Some(handler) = on_drop {
+        row = row
+            .drag_over::<DragPath>(move |s, _drag, _w, _cx| s.bg(drop_hl))
+            .on_drop(cx.listener(move |this, dp: &DragPath, _w, cx| {
+                handler(this, dp.0.clone(), cx);
+            }));
+    }
+    if let Some(handler) = on_ext_drop {
+        row = row
+            .drag_over::<gpui::ExternalPaths>(move |s, _drag, _w, _cx| s.bg(drop_hl))
+            .on_drop(
+                cx.listener(move |this, paths: &gpui::ExternalPaths, _w, cx| {
+                    handler(this, paths.paths().to_vec(), cx);
+                }),
+            );
+    }
+    row.into_any_element()
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -263,6 +263,7 @@ impl Kyde {
             name_input,
             rollback_checked: std::collections::HashSet::new(),
             rollback_delete_added: false,
+            is_git: true,
             current_branch: None,
             branch: BranchPopup::new(cx),
             worktree: WorktreePopup::new(),
@@ -325,6 +326,7 @@ impl Kyde {
             self.files.clear();
             self.stats.clear();
             self.sync.push_files.clear();
+            self.is_git = false;
             self.current_branch = None;
             self.worktree.list.clear();
             self.worktree.popup_open = false;
@@ -392,6 +394,7 @@ impl Kyde {
         }
         self.browse.tree =
             tree::Tree::build_with_dirs(&self.browse.all_files, &self.browse.extra_dirs);
+        self.is_git = snap.is_git;
         self.current_branch = snap.current_branch;
         self.worktree.list = snap.worktrees;
         // Merge-in-progress state (drives the banner). Covers merges we started AND ones

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ use widgets::terminal;
 
 // ── small OS utilities ──
 mod platform;
-use platform::{scratch, shellcmd};
+use platform::{clipboard as os_clipboard, scratch, shellcmd};
 
 // ── workspace crates, aliased back to their old module names ──
 use kyde_config::keymap;
@@ -107,7 +107,10 @@ actions!(
         DeleteFile,
         CloseTab,
         DiffNextChange,
-        DiffPrevChange
+        DiffPrevChange,
+        CopyFiles,
+        CutFiles,
+        PasteFiles
     ]
 );
 // File-finder navigation (fixed keys, context "FileFinder").
@@ -246,6 +249,14 @@ fn apply_keymap(cx: &mut App, km: &Keymap) {
     cx.bind_keys([
         KeyBinding::new("backspace", DeleteFile, Some("Kyde")),
         KeyBinding::new("cmd-backspace", DeleteFile, Some("Kyde")),
+    ]);
+    // File-tree cut/copy/paste (issue #67). Scoped to the "Kyde" root, so the deeper
+    // "CodeEditor" copy/cut/paste bindings win whenever an editor is focused — these only
+    // fire at the app root (a tree row selected, no editor focused).
+    cx.bind_keys([
+        KeyBinding::new("cmd-c", CopyFiles, Some("Kyde")),
+        KeyBinding::new("cmd-x", CutFiles, Some("Kyde")),
+        KeyBinding::new("cmd-v", PasteFiles, Some("Kyde")),
     ]);
     // Jump between diff changes (Alt+↓ / Alt+↑). Global so they fire while the diff editor is
     // focused; no-op when no diff is showing.
@@ -978,6 +989,18 @@ struct BrowseView {
     md_view: Option<gpui::Entity<mdview::MarkdownView>>,
     /// Editor pane width (px) of the markdown side-by-side split (drag-resizable).
     md_editor_w: f32,
+    /// Cut/Copy clipboard for the file tree (issue #67). `None` = nothing copied; a paste
+    /// then falls back to the OS clipboard (Finder file copies, image data).
+    clipboard: Option<TreeClip>,
+}
+
+/// A pending cut/copy of tree paths (issue #67). `cut` moves on paste; otherwise it copies.
+#[derive(Clone)]
+struct TreeClip {
+    /// The rel paths that were cut/copied.
+    paths: Vec<PathBuf>,
+    /// True for a cut (paste moves + clears the clipboard); false for a copy.
+    cut: bool,
 }
 
 impl BrowseView {
@@ -1044,6 +1067,7 @@ impl BrowseView {
             md_preview_scroll: ScrollHandle::new(),
             md_view: None,
             md_editor_w: 480.0,
+            clipboard: None,
         }
     }
 }
@@ -1510,6 +1534,10 @@ struct Kyde {
     name_input: Entity<CodeEditor>,
 
     // Branch switcher (bottom-right status bar + popup)
+    /// Whether the open project is inside a git working tree. `false` for a plain folder —
+    /// the UI hides every git action (branch chip, git menu items, commit/history) and the
+    /// git views explain why instead of offering broken buttons (issue #66).
+    is_git: bool,
     /// Current branch name (repo state — read by refresh/history/status bar, hence kept
     /// directly on `Kyde` rather than in `BranchPopup`).
     current_branch: Option<String>,
@@ -2275,6 +2303,9 @@ impl gpui::AssetSource for Assets {
             "icons/file-clock.svg" => include_bytes!("../assets/icons/file-clock.svg"),
             "icons/pencil.svg" => include_bytes!("../assets/icons/pencil.svg"),
             "icons/trash.svg" => include_bytes!("../assets/icons/trash.svg"),
+            "icons/scissors.svg" => include_bytes!("../assets/icons/scissors.svg"),
+            "icons/copy.svg" => include_bytes!("../assets/icons/copy.svg"),
+            "icons/clipboard.svg" => include_bytes!("../assets/icons/clipboard.svg"),
             "icons/x.svg" => include_bytes!("../assets/icons/x.svg"),
             "icons/maximize-2.svg" => include_bytes!("../assets/icons/maximize-2.svg"),
             "icons/minimize-2.svg" => include_bytes!("../assets/icons/minimize-2.svg"),
@@ -3000,6 +3031,230 @@ mod gpui_smoke_tests {
         (handle, dir)
     }
 
+    /// Renaming a FOLDER (issue #68) moves its whole subtree on disk and repoints every
+    /// piece of Browse UI state that pointed under it — open tabs, the active/selected
+    /// path, and the expanded set — to the new location.
+    #[gpui::test]
+    fn rename_folder_moves_subtree_and_repoints_state(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        std::fs::create_dir_all(dir.join("src/inner")).unwrap();
+        std::fs::write(dir.join("src/inner/mod.rs"), "// mod\n").unwrap();
+        handle
+            .update(cx, |k, _w, cx| {
+                k.refresh(cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, w, cx| {
+                let inner = PathBuf::from("src/inner/mod.rs");
+                k.open_file(inner.clone(), cx);
+                k.browse.expanded.insert(PathBuf::from("src"));
+                k.browse.expanded.insert(PathBuf::from("src/inner"));
+                k.browse.selected_path = Some(inner.clone());
+                // Rename the top folder `src` → `lib`.
+                k.name_prompt = Some(NamePrompt::Rename(PathBuf::from("src")));
+                k.name_input
+                    .update(cx, |e, cx| e.set_content("lib".into(), Lang::PlainText, cx));
+                k.confirm_name_prompt(w, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, _cx| {
+                // Moved on disk.
+                assert!(dir.join("lib/inner/mod.rs").is_file());
+                assert!(!dir.join("src").exists());
+                // Tabs, selection, expansion all repointed under the new name.
+                let moved = PathBuf::from("lib/inner/mod.rs");
+                assert!(k.browse.open_tabs.contains(&moved));
+                assert_eq!(k.browse.open_path.as_ref(), Some(&moved));
+                assert_eq!(k.browse.selected_path.as_ref(), Some(&moved));
+                assert!(k.browse.expanded.contains(&PathBuf::from("lib")));
+                assert!(k.browse.expanded.contains(&PathBuf::from("lib/inner")));
+                assert!(!k.browse.expanded.contains(&PathBuf::from("src")));
+            })
+            .unwrap();
+    }
+
+    /// Tree drag & drop (issue #65): dropping a file onto a folder moves it there; a
+    /// drop that's a no-op (already in that folder) or into a folder's own subtree is
+    /// refused so it can't destroy the source.
+    #[gpui::test]
+    fn drag_drop_moves_into_folder_and_guards_bad_drops(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        std::fs::create_dir_all(dir.join("src/sub")).unwrap();
+        std::fs::write(dir.join("src/sub/keep.rs"), "// keep\n").unwrap();
+        std::fs::write(dir.join("top.txt"), "top\n").unwrap();
+        handle.update(cx, |k, _w, cx| k.refresh(cx)).unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, cx| {
+                // Move top.txt into src/.
+                k.drop_onto_dir(PathBuf::from("top.txt"), PathBuf::from("src"), cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        assert!(dir.join("src/top.txt").is_file(), "file moved into folder");
+        assert!(!dir.join("top.txt").exists(), "source is gone");
+
+        handle
+            .update(cx, |k, _w, cx| {
+                // No-op: already inside src/.
+                k.drop_onto_dir(PathBuf::from("src/top.txt"), PathBuf::from("src"), cx);
+                // Refused: moving src into its own descendant would destroy it.
+                k.drop_onto_dir(PathBuf::from("src"), PathBuf::from("src/sub"), cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        assert!(
+            dir.join("src/top.txt").is_file(),
+            "no-op drop kept the file"
+        );
+        assert!(
+            dir.join("src/sub/keep.rs").is_file(),
+            "self-descendant drop refused"
+        );
+        assert!(
+            !dir.join("src/sub/src").exists(),
+            "src was not moved into its child"
+        );
+    }
+
+    /// File-tree clipboard (issue #67): Copy duplicates (auto-renaming on a clash), Cut
+    /// moves and clears the clipboard, and a folder copies recursively.
+    #[gpui::test]
+    fn clipboard_copy_cut_paste_move_and_duplicate(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        std::fs::create_dir_all(dir.join("a")).unwrap();
+        std::fs::create_dir_all(dir.join("b")).unwrap();
+        std::fs::write(dir.join("a/x.txt"), "x\n").unwrap();
+        handle.update(cx, |k, _w, cx| k.refresh(cx)).unwrap();
+        cx.run_until_parked();
+
+        // Copy a/x.txt, paste into b/ → b/x.txt appears, source stays.
+        handle
+            .update(cx, |k, _w, cx| {
+                k.clip_paths(vec![PathBuf::from("a/x.txt")], false, cx);
+                k.paste_into(PathBuf::from("b"), cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        assert!(dir.join("b/x.txt").is_file(), "copy pasted into b/");
+        assert!(dir.join("a/x.txt").is_file(), "copy left the source");
+
+        // Paste the same copy back into a/ (where it already lives) → auto-renamed.
+        handle
+            .update(cx, |k, _w, cx| {
+                k.clip_paths(vec![PathBuf::from("a/x.txt")], false, cx);
+                k.paste_into(PathBuf::from("a"), cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        assert!(
+            dir.join("a/x copy.txt").is_file(),
+            "clash auto-renamed to ' copy'"
+        );
+
+        // Cut folder a/ into b/ → b/a/x.txt appears, a/ is gone, clipboard cleared.
+        handle
+            .update(cx, |k, _w, cx| {
+                k.clip_paths(vec![PathBuf::from("a")], true, cx);
+                k.paste_into(PathBuf::from("b"), cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        assert!(
+            dir.join("b/a/x.txt").is_file(),
+            "cut moved the folder recursively"
+        );
+        assert!(!dir.join("a").exists(), "cut removed the source folder");
+        handle
+            .update(cx, |k, _w, _cx| {
+                assert!(k.browse.clipboard.is_none(), "cut cleared the clipboard");
+            })
+            .unwrap();
+    }
+
+    /// Renaming a tracked file records it clearly in local history (issue #67 QA): the new
+    /// path gets a "Renamed" marker and the old path a deletion tombstone.
+    #[gpui::test]
+    fn rename_shows_clearly_in_local_history(cx: &mut TestAppContext) {
+        use kyde_local_history::EventKind;
+        let (handle, dir) = boot(cx);
+        // app.tsx is a tracked file in the boot repo; rename it.
+        handle
+            .update(cx, |k, _w, cx| {
+                k.move_path(
+                    std::path::Path::new("app.tsx"),
+                    std::path::Path::new("renamed.tsx"),
+                    "Renaming",
+                    cx,
+                );
+            })
+            .unwrap();
+        cx.run_until_parked();
+        assert!(dir.join("renamed.tsx").is_file());
+        assert!(!dir.join("app.tsx").exists());
+        handle
+            .update(cx, |k, _w, _cx| {
+                let store = k.lh.store.clone().unwrap();
+                let s = store.lock().unwrap();
+                let new_ev = s.events_for(std::path::Path::new("renamed.tsx"));
+                assert!(
+                    new_ev.iter().any(|e| e.label.as_deref() == Some("Renamed")),
+                    "new path has a Renamed marker: {new_ev:?}"
+                );
+                let old_ev = s.events_for(std::path::Path::new("app.tsx"));
+                assert!(
+                    old_ev.iter().any(|e| e.kind == EventKind::Deleted),
+                    "old path is tombstoned: {old_ev:?}"
+                );
+            })
+            .unwrap();
+    }
+
+    /// Pasting raw image data (e.g. a screenshot on the clipboard) writes it as an image
+    /// file in the target folder — into the folder itself, and (regression) into a folder
+    /// even when the paste target resolves to a FILE, without the "not a directory" error.
+    #[gpui::test]
+    fn paste_clipboard_image_writes_a_file(cx: &mut TestAppContext) {
+        let (handle, dir) = boot(cx);
+        std::fs::create_dir_all(dir.join("assets")).unwrap();
+        // A tiny valid-enough PNG byte blob — the paste writes bytes verbatim, it doesn't decode.
+        let png = b"\x89PNG\r\n\x1a\n-fake-image-bytes".to_vec();
+        handle
+            .update(cx, |k, _w, cx| {
+                let img = gpui::Image::from_bytes(gpui::ImageFormat::Png, png.clone());
+                cx.write_to_clipboard(gpui::ClipboardItem::new_image(&img));
+                // Nothing on the internal clipboard, so paste falls through to image data.
+                assert!(k.browse.clipboard.is_none());
+                k.paste_into(PathBuf::from("assets"), cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        let into_folder = dir.join("assets/image.png");
+        assert!(into_folder.is_file(), "image pasted into the folder");
+        assert_eq!(std::fs::read(&into_folder).unwrap(), png);
+
+        // Regression: a paste target that is a FILE must resolve to its parent folder, not
+        // error with "not a directory".
+        std::fs::write(dir.join("note.txt"), "hi\n").unwrap();
+        handle
+            .update(cx, |k, _w, cx| {
+                let img = gpui::Image::from_bytes(gpui::ImageFormat::Png, png.clone());
+                cx.write_to_clipboard(gpui::ClipboardItem::new_image(&img));
+                k.paste_into(PathBuf::from("note.txt"), cx);
+                assert!(k.op_error.is_none(), "no paste error: {:?}", k.op_error);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        assert!(
+            dir.join("image.png").is_file(),
+            "file-target paste landed in the parent"
+        );
+    }
+
     /// New File / New Folder must work in a plain folder with NO git repo (they're pure
     /// filesystem ops), and a created-but-still-empty folder must show in the Browse
     /// tree (file-derived trees can't see empty dirs — `extra_dirs` carries them).
@@ -3051,6 +3306,40 @@ mod gpui_smoke_tests {
                         .any(|r| r.path.as_os_str() == "docs" && r.is_dir),
                     "empty new folder shows in the tree"
                 );
+            })
+            .unwrap();
+    }
+
+    /// A plain (non-git) folder reports `is_git == false`, and `do_git_init` turns it into a
+    /// real repo so the full git UI comes to life (issue #66).
+    #[gpui::test]
+    fn non_git_folder_flags_and_git_init_makes_a_repo(cx: &mut TestAppContext) {
+        isolate_history();
+        static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("kyde-nogit-{}-{seq}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("readme.md"), "hi\n").unwrap();
+
+        let km = Keymap::default();
+        let root = Some(dir.clone());
+        let handle = cx.add_window(move |_w, cx| Kyde::new(root.clone(), km.clone(), false, cx));
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, _cx| {
+                assert!(!k.is_git, "a plain folder is not a git repo");
+                // The Browse tree still works (filesystem walk).
+                assert!(k.browse.all_files.contains(&PathBuf::from("readme.md")));
+            })
+            .unwrap();
+        // git init here, then refresh flips the flag.
+        handle.update(cx, |k, _w, cx| k.do_git_init(cx)).unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, _w, _cx| {
+                assert!(dir.join(".git").is_dir(), "git init created .git");
+                assert!(k.is_git, "is_git flips true after init");
             })
             .unwrap();
     }

--- a/src/platform/clipboard.rs
+++ b/src/platform/clipboard.rs
@@ -1,0 +1,97 @@
+//! Reading file paths off the OS clipboard, so files **copied in Finder** can be pasted
+//! into Kyde's tree (issue #67). gpui's `read_from_clipboard` handles text + images but not
+//! file URLs, so this reaches `NSPasteboard` directly via objc2. Image data pasting rides
+//! gpui's `ClipboardEntry::Image`; only the file-URL case needs this module.
+
+use std::path::PathBuf;
+
+/// File paths currently on the general pasteboard (e.g. files ⌘C-copied in Finder), or an
+/// empty vec when the clipboard holds no file URLs. macOS only; empty elsewhere.
+#[cfg(target_os = "macos")]
+pub(crate) fn file_paths() -> Vec<PathBuf> {
+    use objc2_app_kit::{NSPasteboard, NSPasteboardTypeFileURL};
+
+    // SAFETY: `generalPasteboard` returns the process-wide shared pasteboard; reading its
+    // items and their `public.file-url` string is a pure read (no mutation, no ownership
+    // transfer). Every returned Objective-C object is objc2-retained, and we only borrow
+    // it to copy out a Rust `String`, so there are no lifetime or threading hazards.
+    unsafe {
+        let pb = NSPasteboard::generalPasteboard();
+        let Some(items) = pb.pasteboardItems() else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for item in &items {
+            if let Some(s) = item.stringForType(NSPasteboardTypeFileURL) {
+                // The value is a `file://` URL string; turn it back into a filesystem path.
+                if let Some(p) = url_to_path(&s.to_string()) {
+                    out.push(p);
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn file_paths() -> Vec<PathBuf> {
+    Vec::new()
+}
+
+/// Turn a `file://` URL into a filesystem path, percent-decoding the path portion.
+/// Returns `None` for a non-file URL. Pure — unit-tested below.
+#[cfg(target_os = "macos")]
+fn url_to_path(url: &str) -> Option<PathBuf> {
+    let rest = url.strip_prefix("file://")?;
+    // Drop an authority ("//host") if present — local file URLs use an empty authority, so
+    // the path starts right after the scheme's "//".
+    let path = rest.strip_prefix("localhost").unwrap_or(rest);
+    Some(PathBuf::from(percent_decode(path)))
+}
+
+/// Minimal percent-decoding for file-URL paths (`%20` → space, etc.). Pure.
+#[cfg(target_os = "macos")]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push((hi * 16 + lo) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_url_decodes_to_path() {
+        assert_eq!(
+            url_to_path("file:///Users/me/My%20Docs/a.txt"),
+            Some(PathBuf::from("/Users/me/My Docs/a.txt"))
+        );
+        assert_eq!(
+            url_to_path("file://localhost/tmp/x"),
+            Some(PathBuf::from("/tmp/x"))
+        );
+        assert_eq!(url_to_path("https://example.com"), None);
+    }
+
+    #[test]
+    fn percent_decode_passthrough_and_escapes() {
+        assert_eq!(percent_decode("plain"), "plain");
+        assert_eq!(percent_decode("a%2Fb"), "a/b");
+        assert_eq!(percent_decode("bad%zz"), "bad%zz");
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,3 +1,4 @@
 //! Small OS-integration utilities (no gpui): shell-command install, scratch paths.
+pub(crate) mod clipboard;
 pub(crate) mod scratch;
 pub(crate) mod shellcmd;

--- a/src/render.rs
+++ b/src/render.rs
@@ -310,6 +310,9 @@ impl Render for Kyde {
             .on_action(cx.listener(Self::act_sort_keys))
             .on_action(cx.listener(Self::act_nav_back))
             .on_action(cx.listener(Self::act_nav_forward))
+            .on_action(cx.listener(Self::act_copy_files))
+            .on_action(cx.listener(Self::act_cut_files))
+            .on_action(cx.listener(Self::act_paste_files))
             .on_action(cx.listener(Self::open_keymap))
             .on_action(cx.listener(Self::open_recent_project))
             .on_action(cx.listener(Self::act_open_project))
@@ -690,17 +693,20 @@ impl Kyde {
                         cx.listener(|this, _e, _w, cx| this.sort_object_keys_at_caret(cx)),
                     ));
                 }
-                panel = panel.child(item("Commit").on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |this, _e, _w, cx| this.menu_commit_path(pc.clone(), cx)),
-                ));
-                if self.has_changes_under(p) {
-                    panel = panel.child(item("Rollback").on_mouse_down(
+                // Git commands only when the project is a git repo (issue #66).
+                if self.is_git {
+                    panel = panel.child(item("Commit").on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(move |this, _e, _w, cx| {
-                            this.open_rollback_path(pr.clone(), cx);
-                        }),
+                        cx.listener(move |this, _e, _w, cx| this.menu_commit_path(pc.clone(), cx)),
                     ));
+                    if self.has_changes_under(p) {
+                        panel = panel.child(item("Rollback").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _e, _w, cx| {
+                                this.open_rollback_path(pr.clone(), cx);
+                            }),
+                        ));
+                    }
                 }
                 // Local History for the edited file (issue #7) — hidden when disabled.
                 if self.lh.store.is_some() {
@@ -713,20 +719,22 @@ impl Kyde {
                     ));
                 }
                 // Git remote ops, WebStorm-style (Fetch/Pull always, Push when ahead).
-                panel = panel
-                    .child(item("Fetch").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _e, _w, cx| this.do_fetch(cx)),
-                    ))
-                    .child(item("Pull").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _e, _w, cx| this.do_pull(cx)),
-                    ));
-                if self.sync.ahead.unwrap_or(0) > 0 {
-                    panel = panel.child(item("Push").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _e, _w, cx| this.open_push_modal(cx)),
-                    ));
+                if self.is_git {
+                    panel = panel
+                        .child(item("Fetch").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _e, _w, cx| this.do_fetch(cx)),
+                        ))
+                        .child(item("Pull").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _e, _w, cx| this.do_pull(cx)),
+                        ));
+                    if self.sync.ahead.unwrap_or(0) > 0 {
+                        panel = panel.child(item("Push").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _e, _w, cx| this.open_push_modal(cx)),
+                        ));
+                    }
                 }
                 panel
             }
@@ -835,14 +843,50 @@ impl Kyde {
                         }),
                     ));
                 panel = panel.child(submenu_row(Submenu::New, "New", "New File…", new_flyout));
+                panel = panel.child(ui::menu_divider());
 
-                // Rename applies to files (not folders, for now).
-                if !is_dir {
-                    let pn = p.clone();
-                    panel = panel.child(item("Rename…").on_mouse_down(
+                // Cut / Copy / Paste (issue #67). Copy/Cut act on the whole cmd-selection
+                // when the clicked row is part of it, else just this row. Paste targets a
+                // folder (or the clicked file's folder), pulling from kyde's clipboard, then
+                // Finder file copies, then image data.
+                {
+                    let clip_paths = |this: &Kyde, row: &std::path::Path| -> Vec<PathBuf> {
+                        if this.browse.multi_selected.iter().any(|s| s == row)
+                            && this.browse.multi_selected.len() > 1
+                        {
+                            this.browse.multi_selected.clone()
+                        } else {
+                            vec![row.to_path_buf()]
+                        }
+                    };
+                    let (pcut, pcopy) = (p.clone(), p.clone());
+                    panel = panel
+                        .child(item("Cut").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _e, _w, cx| {
+                                let paths = clip_paths(this, &pcut);
+                                this.clip_paths(paths, true, cx);
+                            }),
+                        ))
+                        .child(item("Copy").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _e, _w, cx| {
+                                let paths = clip_paths(this, &pcopy);
+                                this.clip_paths(paths, false, cx);
+                            }),
+                        ));
+                    // Paste destination: the folder itself, else the file's parent folder.
+                    let dest = if is_dir {
+                        p.clone()
+                    } else {
+                        p.parent()
+                            .map(std::path::Path::to_path_buf)
+                            .unwrap_or_default()
+                    };
+                    panel = panel.child(item("Paste").on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(move |this, _e, window, cx| {
-                            this.start_rename(pn.clone(), window, cx);
+                        cx.listener(move |this, _e, _w, cx| {
+                            this.paste_into(dest.clone(), cx);
                         }),
                     ));
                 }
@@ -859,46 +903,29 @@ impl Kyde {
                         }),
                     ));
                 }
+                panel = panel.child(ui::menu_divider());
 
-                // Git ▸ — commit / rollback / history / fetch / pull / push, grouped.
-                let ph = p.clone();
-                let mut git_flyout = div();
-                if self.has_changes_under(p) {
-                    git_flyout = git_flyout
-                        .child(item("Commit").on_mouse_down(
+                // Rename / Delete — act on the file/folder itself. Rename covers both files
+                // and folders (a folder rename carries its whole subtree).
+                {
+                    let (pn, pd) = (p.clone(), p.clone());
+                    panel = panel
+                        .child(item("Rename…").on_mouse_down(
                             MouseButton::Left,
-                            cx.listener(move |this, _e, _w, cx| {
-                                this.menu_commit_path(pc.clone(), cx);
+                            cx.listener(move |this, _e, window, cx| {
+                                this.start_rename(pn.clone(), window, cx);
                             }),
                         ))
-                        .child(item("Rollback").on_mouse_down(
+                        .child(item("Delete…").on_mouse_down(
                             MouseButton::Left,
-                            cx.listener(move |this, _e, _w, cx| {
-                                this.open_rollback_path(pr.clone(), cx);
-                            }),
+                            cx.listener(move |this, _e, _w, cx| this.open_delete(pd.clone(), cx)),
                         ));
                 }
-                git_flyout = git_flyout
-                    .child(item("Git History").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |this, _e, _w, cx| this.enter_history_for(ph.clone(), cx)),
-                    ))
-                    .child(item("Fetch").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _e, _w, cx| this.do_fetch(cx)),
-                    ))
-                    .child(item("Pull").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _e, _w, cx| this.do_pull(cx)),
-                    ));
-                if self.sync.ahead.unwrap_or(0) > 0 {
-                    git_flyout = git_flyout.child(item("Push").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _e, _w, cx| this.open_push_modal(cx)),
-                    ));
-                }
-                panel = panel.child(submenu_row(Submenu::Git, "Git", "Commit", git_flyout));
 
+                // Local History + Git group (each conditional) — its own divided section.
+                if self.lh.store.is_some() || self.is_git {
+                    panel = panel.child(ui::menu_divider());
+                }
                 // Local History (issue #7) — file OR folder scope; hidden when disabled.
                 if self.lh.store.is_some() {
                     let pl = p.clone();
@@ -909,15 +936,57 @@ impl Kyde {
                         }),
                     ));
                 }
-                let pd = p.clone();
+
+                // Git ▸ — commit / rollback / history / fetch / pull / push, grouped.
+                // The whole submenu is hidden for a plain (non-git) folder (issue #66).
+                if self.is_git {
+                    let ph = p.clone();
+                    let mut git_flyout = div();
+                    if self.has_changes_under(p) {
+                        git_flyout = git_flyout
+                            .child(item("Commit").on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, _e, _w, cx| {
+                                    this.menu_commit_path(pc.clone(), cx);
+                                }),
+                            ))
+                            .child(item("Rollback").on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, _e, _w, cx| {
+                                    this.open_rollback_path(pr.clone(), cx);
+                                }),
+                            ));
+                    }
+                    git_flyout = git_flyout
+                        .child(item("Git History").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _e, _w, cx| {
+                                this.enter_history_for(ph.clone(), cx);
+                            }),
+                        ))
+                        .child(item("Fetch").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _e, _w, cx| this.do_fetch(cx)),
+                        ))
+                        .child(item("Pull").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _e, _w, cx| this.do_pull(cx)),
+                        ));
+                    if self.sync.ahead.unwrap_or(0) > 0 {
+                        git_flyout = git_flyout.child(item("Push").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _e, _w, cx| this.open_push_modal(cx)),
+                        ));
+                    }
+                    panel = panel.child(submenu_row(Submenu::Git, "Git", "Commit", git_flyout));
+                }
+
+                // Reveal in Finder — its own trailing group.
                 panel
+                    .child(ui::menu_divider())
                     .child(item("Reveal in Finder").on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |this, _e, _w, cx| this.reveal_in_os(&pv, cx)),
-                    ))
-                    .child(item("Delete…").on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |this, _e, _w, cx| this.open_delete(pd.clone(), cx)),
                     ))
             }
             MenuTarget::Tab(idx) => {

--- a/src/views/branch.rs
+++ b/src/views/branch.rs
@@ -241,10 +241,12 @@ impl Kyde {
                     })
                     // Worktree chip only when the repo has linked worktrees (list = main +
                     // linked, so > 1) — zero chrome otherwise.
-                    .when(self.worktree.list.len() > 1, |d| {
+                    .when(self.is_git && self.worktree.list.len() > 1, |d| {
                         d.child(self.render_worktree_chip(cx))
                     })
-                    .child(chip),
+                    // The branch chip is a git action — hidden for a plain (non-git)
+                    // folder, where it would only show "(no branch)" (issue #66).
+                    .when(self.is_git, |d| d.child(chip)),
             )
             .into_any_element()
     }

--- a/src/views/browse.rs
+++ b/src/views/browse.rs
@@ -357,6 +357,37 @@ impl Kyde {
                     .then(|| status_by_path.get(&r.path))
                     .flatten()
                     .map_or(theme::get().text, |&s| status_color(s));
+                // Drag & drop (issue #65): every real repo file/folder is a drag source;
+                // real directories (incl. the repo-root row, path "") are drop targets that
+                // move the dropped path inside them. Scratch rows (absolute paths / the
+                // "Scratches" pseudo-group) are excluded — they live outside the project.
+                let is_scratch = r.path.is_absolute() || r.path == scratch_group;
+                let draggable = !is_root && !is_scratch;
+                let on_drop: Option<ui::tree::OnDrop<Self>> = (is_dir && !is_scratch).then(|| {
+                    let dest = r.path.clone();
+                    let f: ui::tree::OnDrop<Self> = Box::new(move |this: &mut Self, src, cx| {
+                        this.drop_onto_dir(src, dest.clone(), cx);
+                    });
+                    f
+                });
+                // Finder files dropped ON this row (issue #67): a folder takes them inside
+                // itself; a file takes them into its parent folder — so the highlighted row
+                // is exactly where they'll land.
+                let on_ext_drop: Option<ui::tree::OnExtDrop<Self>> = (!is_scratch).then(|| {
+                    let dest = if is_dir {
+                        r.path.clone()
+                    } else {
+                        r.path
+                            .parent()
+                            .map(std::path::Path::to_path_buf)
+                            .unwrap_or_default()
+                    };
+                    let f: ui::tree::OnExtDrop<Self> =
+                        Box::new(move |this: &mut Self, paths, cx| {
+                            this.drop_external_paths(paths, dest.clone(), cx);
+                        });
+                    f
+                });
                 ui::tree::item(
                     cx,
                     self.dragging(Divider::Tree),
@@ -369,6 +400,9 @@ impl Kyde {
                     name_color,
                     None,
                     None,
+                    draggable,
+                    on_drop,
+                    on_ext_drop,
                     move |this, e, window, cx| {
                         // Cmd-click on a FILE toggles it in the multi-selection (for
                         // "Compare Selected" — issue #42) without opening it. The
@@ -451,6 +485,7 @@ impl Kyde {
                 }),
             );
         let tree = div()
+            .id("browse-tree-pane")
             .flex()
             .flex_col()
             .relative()
@@ -464,6 +499,13 @@ impl Kyde {
             .font_family(ui)
             // A touch larger than the editor/code size for readability.
             .text_size(px(theme::get().ui_font_size + 3.0))
+            // Catch-all for Finder files dropped on the tree's EMPTY area (below the rows):
+            // they go to the repo root. Drops onto a row are handled per-row (with that
+            // row highlighted) — see `on_ext_drop` above (issue #67). No pane-wide tint here,
+            // so the highlight only ever marks the specific target folder.
+            .on_drop(cx.listener(|this, ep: &gpui::ExternalPaths, _w, cx| {
+                this.drop_external_paths(ep.paths().to_vec(), PathBuf::new(), cx);
+            }))
             .child({
                 let rows_pane = div()
                     .id("browse-tree")

--- a/src/views/commit.rs
+++ b/src/views/commit.rs
@@ -12,23 +12,17 @@ impl Kyde {
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let t = theme::get();
+        // A plain (non-git) folder has no git actions at all — say so clearly and offer to
+        // initialise a repository, rather than showing an empty "nothing to commit" screen
+        // that looks broken (issue #66).
+        if !self.is_git {
+            return self.render_no_git(ui, cx);
+        }
         let commit_n = self.files.len();
         let push_n = self.sync.push_files.len();
         // Nothing to commit AND nothing to push → a single centered message.
         if commit_n == 0 && push_n == 0 {
-            return div()
-                .flex()
-                .flex_1()
-                .h_full()
-                .items_center()
-                .justify_center()
-                .bg(t.main_bg)
-                .rounded(px(theme::ISLAND_RADIUS))
-                .font_family(ui)
-                .text_size(px(theme::get().ui_font_size + 1.0))
-                .text_color(t.line_number)
-                .child("You have nothing to commit or push")
-                .into_any_element();
+            return ui::empty_state("You have nothing to commit or push", ui).into_any_element();
         }
 
         // Only tabs with content are shown; fall back to the available one if the selected
@@ -261,6 +255,9 @@ impl Kyde {
                     name_color,
                     Some(checked),
                     stats,
+                    false,
+                    None,
+                    None,
                     move |this, _e, _w, cx| {
                         if is_dir {
                             this.toggle_commit_dir(p_act.clone(), cx);
@@ -770,6 +767,69 @@ impl Kyde {
             self.diff.right.update(cx, |e, cx| {
                 e.set_content(String::new(), Lang::PlainText, cx);
             });
+        }
+        cx.notify();
+    }
+
+    /// The Commit/Git view for a plain folder that is NOT a git repository (issue #66):
+    /// state plainly why there are no git actions, and offer to `git init` here.
+    pub(crate) fn render_no_git(
+        &self,
+        ui: &'static str,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let t = theme::get();
+        let init_btn = btn_primary("git-init", "Initialize Git Repository").on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|this, _e, _w, cx| this.do_git_init(cx)),
+        );
+        div()
+            .flex()
+            .flex_1()
+            .h_full()
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap_3()
+            .bg(t.main_bg)
+            .rounded(px(theme::ISLAND_RADIUS))
+            .font_family(ui)
+            .child(
+                svg()
+                    .path("icons/git-branch.svg")
+                    .size(px(40.0))
+                    .text_color(t.line_number),
+            )
+            .child(
+                div()
+                    .text_size(px(theme::get().ui_font_size + 3.0))
+                    .text_color(t.text)
+                    .child("Not a git repository"),
+            )
+            .child(
+                div()
+                    .max_w(px(360.0))
+                    .text_center()
+                    .text_size(px(theme::get().ui_font_size))
+                    .text_color(t.secondary_text)
+                    .child(
+                        "This folder isn’t tracked by git, so there’s nothing to commit, \
+                         push, or browse in history. Initialize a repository to start \
+                         versioning it.",
+                    ),
+            )
+            .child(init_btn)
+            .into_any_element()
+    }
+
+    /// `git init` the open project, then refresh so the full git UI comes to life.
+    pub(crate) fn do_git_init(&mut self, cx: &mut Context<Self>) {
+        let Some(root) = self.repo_root.clone() else {
+            return;
+        };
+        match git::Repo::init(&root) {
+            Ok(_) => self.refresh(cx),
+            Err(e) => self.fail("Initializing repository", e),
         }
         cx.notify();
     }

--- a/src/views/file_ops.rs
+++ b/src/views/file_ops.rs
@@ -3,6 +3,59 @@
 
 use crate::*;
 
+/// If `p` is `old` or lives under it, return `p` with the `old` prefix replaced by `new`
+/// (so renaming a folder repoints every path beneath it); `None` when `p` is unrelated.
+pub(crate) fn remap_under(
+    p: &std::path::Path,
+    old: &std::path::Path,
+    new: &std::path::Path,
+) -> Option<PathBuf> {
+    if p == old {
+        return Some(new.to_path_buf());
+    }
+    p.strip_prefix(old).ok().map(|rest| new.join(rest))
+}
+
+/// Recursively copy `src` → `dst` (a single file, or a whole directory tree). Parents of
+/// `dst` are created as needed. Used by paste/duplicate (issue #67).
+fn copy_tree(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Result<()> {
+    if src.is_dir() {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            copy_tree(&entry.path(), &dst.join(entry.file_name()))?;
+        }
+    } else {
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(src, dst)?;
+    }
+    Ok(())
+}
+
+/// Split a filename into `(stem, ext_with_dot)` at the LAST dot — but only when the dot
+/// isn't the leading char (so a dotfile like `.gitignore` keeps its whole name). Pure.
+fn split_name(name: &str) -> (String, String) {
+    match name.rfind('.') {
+        Some(i) if i > 0 => (name[..i].to_string(), name[i..].to_string()),
+        _ => (name.to_string(), String::new()),
+    }
+}
+
+/// File extension for a clipboard image's format (issue #67 — pasted image → a file).
+fn image_ext(format: gpui::ImageFormat) -> &'static str {
+    match format {
+        gpui::ImageFormat::Png => "png",
+        gpui::ImageFormat::Jpeg => "jpg",
+        gpui::ImageFormat::Gif => "gif",
+        gpui::ImageFormat::Webp => "webp",
+        gpui::ImageFormat::Bmp => "bmp",
+        gpui::ImageFormat::Tiff => "tiff",
+        gpui::ImageFormat::Svg => "svg",
+    }
+}
+
 impl Kyde {
     pub(crate) fn render_delete_modal(
         &self,
@@ -44,29 +97,11 @@ impl Kyde {
                 cx.listener(|this, _e, _w, cx| this.do_delete(cx)),
             );
 
-        let panel = div()
-            .w(px(420.0))
-            .flex()
-            .flex_col()
-            .gap_3()
-            .p_4()
-            .bg(t.frame_bg)
-            .border_1()
-            .border_color(t.divider)
-            .rounded(px(theme::ISLAND_RADIUS))
-            .shadow_lg()
-            .font_family(ui)
-            .text_size(px(theme::get().ui_font_size + 1.0))
-            .occlude()
-            .child(div().text_color(t.text).child(format!("Delete {kind}?")))
-            .child(
-                div()
-                    .text_color(t.secondary_text)
-                    .text_size(px(theme::get().ui_font_size))
-                    .child(format!(
-                        "“{name}” will be permanently deleted from disk. This can't be undone."
-                    )),
-            )
+        let panel = ui::modal_panel(420.0, ui)
+            .child(ui::dialog_title(format!("Delete {kind}?")))
+            .child(ui::dialog_body(format!(
+                "“{name}” will be permanently deleted from disk. This can't be undone."
+            )))
             .child(ui::modal_footer().child(cancel).child(confirm));
         overlay(cx, true).child(panel).into_any_element()
     }
@@ -104,7 +139,7 @@ impl Kyde {
                 cx.listener(|this, _e, window, cx| this.confirm_name_prompt(window, cx)),
             );
 
-        let panel = div()
+        let panel = ui::modal_panel(420.0, ui)
             .key_context("FileFinder")
             .on_action(cx.listener(|this, _: &FinderConfirm, window, cx| {
                 this.confirm_name_prompt(window, cx);
@@ -112,20 +147,7 @@ impl Kyde {
             .on_action(cx.listener(|this, _: &FinderClose, window, cx| {
                 this.cancel_name_prompt(window, cx);
             }))
-            .w(px(420.0))
-            .flex()
-            .flex_col()
-            .gap_3()
-            .p_4()
-            .bg(t.frame_bg)
-            .border_1()
-            .border_color(t.divider)
-            .rounded(px(theme::ISLAND_RADIUS))
-            .shadow_lg()
-            .font_family(ui)
-            .text_size(px(theme::get().ui_font_size + 1.0))
-            .occlude()
-            .child(div().text_color(t.text).child(title))
+            .child(ui::dialog_title(title))
             .child(
                 div()
                     .px_2()
@@ -266,32 +288,14 @@ impl Kyde {
                 let dst = path
                     .parent()
                     .map_or_else(|| PathBuf::from(&name), |d| d.join(&name));
-                match self.fs_rename(&path, &dst) {
-                    Ok(()) => {
-                        // Repoint any open tab / selection from the old path to the new one.
-                        for t in &mut self.browse.open_tabs {
-                            if *t == path {
-                                *t = dst.clone();
-                            }
-                        }
-                        let was_open = self.browse.open_path.as_ref() == Some(&path);
-                        if self.browse.selected_path.as_ref() == Some(&path) {
-                            self.browse.selected_path = Some(dst.clone());
-                        }
-                        self.refresh(cx);
-                        if was_open {
-                            self.open_file(dst, cx);
-                        }
-                    }
-                    Err(e) => self.fail("Renaming", e),
-                }
+                self.move_path(&path, &dst, "Renaming", cx);
             }
         }
         cx.notify();
     }
 
     /// `rel` resolved against the open project's root.
-    fn project_abs(&self, rel: &std::path::Path) -> anyhow::Result<PathBuf> {
+    pub(crate) fn project_abs(&self, rel: &std::path::Path) -> anyhow::Result<PathBuf> {
         let root = self
             .repo_root
             .as_ref()
@@ -321,6 +325,317 @@ impl Kyde {
         }
         std::fs::create_dir_all(&full)?;
         Ok(())
+    }
+
+    /// Move/rename `from` → `to` on disk, then repoint every piece of Browse UI state that
+    /// pointed at or under `from` — open tabs, the active/selected path, expansion, and
+    /// `extra_dirs` — so a folder move carries its whole subtree. Reopens the active file at
+    /// its new path. No-op when `to == from`. `ctx` labels any error banner.
+    pub(crate) fn move_path(
+        &mut self,
+        from: &std::path::Path,
+        to: &std::path::Path,
+        ctx: &str,
+        cx: &mut Context<Self>,
+    ) {
+        if to == from {
+            cx.notify();
+            return;
+        }
+        if let Err(e) = self.fs_rename(from, to) {
+            self.fail(ctx, e);
+            cx.notify();
+            return;
+        }
+        // Log it in local history so a rename/move reads clearly (issue #67 QA): old path
+        // tombstoned, new path labeled. Must run AFTER the fs move (reads the new location).
+        let lh_label = if ctx == "Renaming" {
+            "Renamed"
+        } else {
+            "Moved here"
+        };
+        self.lh_record_rename(from, to, lh_label, cx);
+        for t in &mut self.browse.open_tabs {
+            if let Some(n) = remap_under(t, from, to) {
+                *t = n;
+            }
+        }
+        let reopen = self
+            .browse
+            .open_path
+            .as_ref()
+            .and_then(|o| remap_under(o, from, to));
+        if let Some(sel) = &self.browse.selected_path {
+            if let Some(n) = remap_under(sel, from, to) {
+                self.browse.selected_path = Some(n);
+            }
+        }
+        self.browse.expanded = std::mem::take(&mut self.browse.expanded)
+            .into_iter()
+            .map(|e| remap_under(&e, from, to).unwrap_or(e))
+            .collect();
+        for d in &mut self.browse.extra_dirs {
+            if let Some(n) = remap_under(d, from, to) {
+                *d = n;
+            }
+        }
+        self.refresh(cx);
+        if let Some(o) = reopen {
+            self.open_file(o, cx);
+        }
+        cx.notify();
+    }
+
+    /// Drop the dragged path `src` into the directory `dest_dir` (rel; `""` = repo root) —
+    /// the tree drag & drop (issue #65). Ignores no-op drops (already in that folder) and
+    /// refuses to move a folder into itself or one of its own descendants.
+    pub(crate) fn drop_onto_dir(
+        &mut self,
+        src: PathBuf,
+        dest_dir: PathBuf,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(name) = src.file_name() else {
+            return;
+        };
+        // Already living directly in the destination → nothing to do.
+        let src_parent = src
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default();
+        if src_parent == dest_dir {
+            return;
+        }
+        // Can't drop a folder onto itself or into its own subtree.
+        if dest_dir == src || dest_dir.starts_with(&src) {
+            return;
+        }
+        let to = dest_dir.join(name);
+        // Reveal the moved item: make sure its new home is expanded.
+        self.browse.expanded.insert(dest_dir);
+        self.move_path(&src, &to, "Moving", cx);
+    }
+
+    // ── Cut / Copy / Paste (issue #67) ────────────────────────────────────────────────
+
+    /// The tree paths a clipboard/keyboard op should act on: the cmd-click multi-selection
+    /// if any, else the single selected row. Scratch + absolute + the repo-root row are
+    /// dropped (they aren't movable project files).
+    pub(crate) fn tree_selection(&self) -> Vec<PathBuf> {
+        let raw = if self.browse.multi_selected.is_empty() {
+            self.browse.selected_path.clone().into_iter().collect()
+        } else {
+            self.browse.multi_selected.clone()
+        };
+        raw.into_iter()
+            .filter(|p| !p.as_os_str().is_empty() && !p.is_absolute())
+            .collect()
+    }
+
+    /// Put `paths` on the tree clipboard (issue #67). `cut` → a later paste moves them;
+    /// otherwise it copies. Empty selection is a no-op.
+    pub(crate) fn clip_paths(&mut self, paths: Vec<PathBuf>, cut: bool, cx: &mut Context<Self>) {
+        let paths: Vec<PathBuf> = paths
+            .into_iter()
+            .filter(|p| !p.as_os_str().is_empty() && !p.is_absolute())
+            .collect();
+        if paths.is_empty() {
+            self.close_menu(cx);
+            return;
+        }
+        self.browse.clipboard = Some(TreeClip { paths, cut });
+        self.close_menu(cx);
+        cx.notify();
+    }
+
+    /// Paste into the directory `dest_dir` (rel; `""` = repo root). Priority: the internal
+    /// tree clipboard (cut = move, copy = duplicate), then files copied in Finder, then
+    /// image data on the clipboard (written as `image.<ext>` in the folder). Issue #67.
+    pub(crate) fn paste_into(&mut self, dest_dir: PathBuf, cx: &mut Context<Self>) {
+        self.close_menu(cx);
+        // Normalize the target to a real directory (a file → its parent), creating it if
+        // needed — so a write never hits "not a directory" (issue #67 QA).
+        let dest_dir = self.ensure_dest_dir(dest_dir);
+        // 1) Internal clipboard — kyde's own cut/copy.
+        if let Some(clip) = self.browse.clipboard.clone() {
+            let mut last = None;
+            for src in &clip.paths {
+                let Some(name) = src.file_name() else {
+                    continue;
+                };
+                if clip.cut {
+                    // A move: skip a no-op (already here) or a move into its own subtree.
+                    let parent = src
+                        .parent()
+                        .map(std::path::Path::to_path_buf)
+                        .unwrap_or_default();
+                    if parent == dest_dir || dest_dir == *src || dest_dir.starts_with(src) {
+                        continue;
+                    }
+                    let to = dest_dir.join(name);
+                    self.move_path(src, &to, "Moving", cx);
+                    last = Some(to);
+                } else {
+                    let to = self.unique_dest(&dest_dir, name);
+                    if let Err(e) = self.copy_path(src, &to) {
+                        self.fail("Pasting", e);
+                    } else {
+                        last = Some(to);
+                    }
+                }
+            }
+            if clip.cut {
+                self.browse.clipboard = None;
+            }
+            self.finish_paste(dest_dir, last, cx);
+            return;
+        }
+        // 2) Files copied in Finder (absolute source paths).
+        let files = os_clipboard::file_paths();
+        if !files.is_empty() {
+            let mut last = None;
+            for src_abs in &files {
+                if let Some(to) = self.copy_external_into(src_abs, &dest_dir) {
+                    last = Some(to);
+                }
+            }
+            self.finish_paste(dest_dir, last, cx);
+            return;
+        }
+        // 3) Raw image data on the clipboard → a new image file in the folder.
+        if let Some(item) = cx.read_from_clipboard() {
+            for entry in item.entries() {
+                if let gpui::ClipboardEntry::Image(img) = entry {
+                    let name = format!("image.{}", image_ext(img.format));
+                    let to = self.unique_dest(&dest_dir, std::ffi::OsStr::new(&name));
+                    match self.project_abs(&to) {
+                        Ok(abs) => {
+                            if let Some(p) = abs.parent() {
+                                let _ = std::fs::create_dir_all(p);
+                            }
+                            if let Err(e) = std::fs::write(&abs, &img.bytes) {
+                                self.fail("Pasting image", e);
+                            } else {
+                                self.finish_paste(dest_dir, Some(to), cx);
+                                return;
+                            }
+                        }
+                        Err(e) => self.fail("Pasting image", e),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Files dragged in from Finder (issue #67): copy each into `dest_dir` (rel; `""` = repo
+    /// root). Dropping onto a file row targets its folder (the row wiring passes the parent).
+    /// `paths` are absolute OS paths.
+    pub(crate) fn drop_external_paths(
+        &mut self,
+        paths: Vec<PathBuf>,
+        dest_dir: PathBuf,
+        cx: &mut Context<Self>,
+    ) {
+        if paths.is_empty() {
+            return;
+        }
+        let dest = self.ensure_dest_dir(dest_dir);
+        let mut last = None;
+        for src in &paths {
+            if let Some(to) = self.copy_external_into(src, &dest) {
+                last = Some(to);
+            }
+        }
+        self.finish_paste(dest, last, cx);
+    }
+
+    /// Resolve a paste destination to a real, existing directory (rel; `""` = repo root).
+    /// A file path becomes its parent folder; a missing directory is created. Guarantees the
+    /// caller can write `<dest>/<name>` without hitting a "not a directory" error.
+    fn ensure_dest_dir(&self, dest_dir: PathBuf) -> PathBuf {
+        let Some(root) = self.repo_root.clone() else {
+            return dest_dir;
+        };
+        let rel = if root.join(&dest_dir).is_file() {
+            dest_dir
+                .parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or_default()
+        } else {
+            dest_dir
+        };
+        let _ = std::fs::create_dir_all(root.join(&rel));
+        rel
+    }
+
+    /// Shared tail of a paste: reveal the destination, select the last pasted item, refresh.
+    fn finish_paste(&mut self, dest_dir: PathBuf, last: Option<PathBuf>, cx: &mut Context<Self>) {
+        self.browse.expanded.insert(dest_dir);
+        if let Some(l) = last {
+            self.browse.selected_path = Some(l);
+        }
+        self.refresh(cx);
+        cx.notify();
+    }
+
+    /// Copy `from_rel` → `to_rel` within the project (recursive for a directory).
+    fn copy_path(
+        &self,
+        from_rel: &std::path::Path,
+        to_rel: &std::path::Path,
+    ) -> anyhow::Result<()> {
+        let (src, dst) = (self.project_abs(from_rel)?, self.project_abs(to_rel)?);
+        copy_tree(&src, &dst)
+    }
+
+    /// Copy an EXTERNAL (absolute) source path into `dest_dir` (rel), auto-renaming to dodge
+    /// a name clash. Returns the rel destination on success. Used for Finder-copied files.
+    fn copy_external_into(
+        &mut self,
+        src_abs: &std::path::Path,
+        dest_dir: &std::path::Path,
+    ) -> Option<PathBuf> {
+        let name = src_abs.file_name()?;
+        let to = self.unique_dest(dest_dir, name);
+        let dst = self.project_abs(&to).ok()?;
+        match copy_tree(src_abs, &dst) {
+            Ok(()) => Some(to),
+            Err(e) => {
+                self.fail("Pasting", e);
+                None
+            }
+        }
+    }
+
+    /// A rel path inside `dir_rel` for `name` that doesn't already exist, appending
+    /// " copy", " copy 2", … before the extension (Finder-style) on a clash.
+    fn unique_dest(&self, dir_rel: &std::path::Path, name: &std::ffi::OsStr) -> PathBuf {
+        let join = |n: &str| {
+            if dir_rel.as_os_str().is_empty() {
+                PathBuf::from(n)
+            } else {
+                dir_rel.join(n)
+            }
+        };
+        let taken = |p: &std::path::Path| self.project_abs(p).is_ok_and(|a| a.exists());
+        let name = name.to_string_lossy();
+        let first = join(&name);
+        if !taken(&first) {
+            return first;
+        }
+        let (stem, ext) = split_name(&name);
+        for i in 1..10_000 {
+            let cand = if i == 1 {
+                format!("{stem} copy{ext}")
+            } else {
+                format!("{stem} copy {i}{ext}")
+            };
+            let p = join(&cand);
+            if !taken(&p) {
+                return p;
+            }
+        }
+        join(&format!("{stem} copy{ext}"))
     }
 
     /// Move `from` to `to` within the project. Refuses to clobber an existing target.
@@ -441,6 +756,57 @@ impl Kyde {
         }
         if let Some(path) = self.browse.selected_path.clone() {
             self.open_delete(path, cx);
+        }
+    }
+
+    /// ⌘C — copy the tree selection (issue #67). Browse mode only.
+    pub(crate) fn act_copy_files(&mut self, _: &CopyFiles, _: &mut Window, cx: &mut Context<Self>) {
+        if self.mode != Mode::Browse {
+            return;
+        }
+        let sel = self.tree_selection();
+        self.clip_paths(sel, false, cx);
+    }
+
+    /// ⌘X — cut the tree selection (paste moves it). Browse mode only.
+    pub(crate) fn act_cut_files(&mut self, _: &CutFiles, _: &mut Window, cx: &mut Context<Self>) {
+        if self.mode != Mode::Browse {
+            return;
+        }
+        let sel = self.tree_selection();
+        self.clip_paths(sel, true, cx);
+    }
+
+    /// ⌘V — paste into the selected folder (or the selected file's folder, else the repo
+    /// root). Browse mode only.
+    pub(crate) fn act_paste_files(
+        &mut self,
+        _: &PasteFiles,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.mode != Mode::Browse {
+            return;
+        }
+        let dest = self.paste_target();
+        self.paste_into(dest, cx);
+    }
+
+    /// Where a keyboard ⌘V pastes: a selected directory → into it; a selected file → its
+    /// parent folder; nothing selected → the repo root.
+    fn paste_target(&self) -> PathBuf {
+        match self.browse.selected_path.clone() {
+            Some(p) if !p.is_absolute() && !p.as_os_str().is_empty() => {
+                let is_dir = self.repo_root.as_ref().is_some_and(|r| r.join(&p).is_dir());
+                if is_dir {
+                    p
+                } else {
+                    p.parent()
+                        .map(std::path::Path::to_path_buf)
+                        .unwrap_or_default()
+                }
+            }
+            _ => PathBuf::new(),
         }
     }
 

--- a/src/views/history.rs
+++ b/src/views/history.rs
@@ -16,6 +16,10 @@ impl Kyde {
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let t = theme::get();
+        // No git repository → no history. Reuse the Commit view's explanation (issue #66).
+        if !self.is_git {
+            return self.render_no_git(ui, cx);
+        }
 
         // ── header: branch chip + commit search + compare-mode segmented control ──
         let rev_label: SharedString = format!("⎇ {}", self.history.rev).into();
@@ -367,6 +371,9 @@ impl Kyde {
                     selected,
                     name,
                     name_color,
+                    None,
+                    None,
+                    false,
                     None,
                     None,
                     move |this, _e, _w, cx| {

--- a/src/views/local_history.rs
+++ b/src/views/local_history.rs
@@ -38,6 +38,27 @@ pub(crate) fn lh_now_ms() -> u64 {
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
+/// Every file (not directory) under `dir`, recursively — for recording a folder rename
+/// file-by-file in local history. Best-effort: unreadable subdirs are skipped.
+fn lh_walk_files(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
 /// The local timezone's offset from UTC in minutes, read once per launch (`date +%z`
 /// — no chrono/libc dependency; a failure falls back to UTC).
 fn tz_offset_min() -> i32 {
@@ -310,6 +331,66 @@ impl Kyde {
                 let Ok(mut s) = store.lock() else { return };
                 for (rel, content) in contents {
                     let _ = s.record(&rel, &content, EventKind::Label, Some(label.clone()), now);
+                }
+            })
+            .detach();
+    }
+
+    /// Record a rename/move in local history (issue #67 QA): the OLD path gets a snapshot
+    /// then a deletion tombstone ("renamed away here"), and the NEW path a clearly `label`ed
+    /// snapshot ("arrived there") — so a rename reads unambiguously in the timeline. `to` is
+    /// already on disk (call AFTER the fs move). A directory is walked file-by-file (local
+    /// history is per-file); content-hash dedup keeps the later refresh scan from duplicating
+    /// these. No-op when disabled / the moved content is unreadable (e.g. binary).
+    pub(crate) fn lh_record_rename(
+        &mut self,
+        from: &std::path::Path,
+        to: &std::path::Path,
+        label: &str,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.lh.cfg.enabled || self.lh.store.is_none() {
+            return;
+        }
+        let Some(store) = self.lh.store.clone() else {
+            return;
+        };
+        let Some(to_abs) = self.lh_abs(to) else {
+            return;
+        };
+        // (old_rel, new_rel, content) for every moved FILE (a dir expands to its files).
+        let mut pairs: Vec<(PathBuf, PathBuf, String)> = Vec::new();
+        if to_abs.is_dir() {
+            for abs in lh_walk_files(&to_abs) {
+                if let (Ok(rest), Ok(content)) =
+                    (abs.strip_prefix(&to_abs), std::fs::read_to_string(&abs))
+                {
+                    pairs.push((from.join(rest), to.join(rest), content));
+                }
+            }
+        } else if let Ok(content) = std::fs::read_to_string(&to_abs) {
+            pairs.push((from.to_path_buf(), to.to_path_buf(), content));
+        }
+        if pairs.is_empty() {
+            return;
+        }
+        let label = label.to_string();
+        cx.background_executor()
+            .spawn(async move {
+                let now = lh_now_ms();
+                let Ok(mut s) = store.lock() else { return };
+                for (old_rel, new_rel, content) in pairs {
+                    // Give the old path history (if it lacked any), then tombstone it.
+                    let _ = s.record(&old_rel, &content, EventKind::Change, None, now);
+                    let _ = s.record_deletion(&old_rel, now);
+                    // A clear, always-appended marker on the new path.
+                    let _ = s.record(
+                        &new_rel,
+                        &content,
+                        EventKind::Label,
+                        Some(label.clone()),
+                        now,
+                    );
                 }
             })
             .detach();
@@ -832,8 +913,6 @@ impl Kyde {
         &mut self,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let ui = theme::font::UI_FAMILY;
-        let t = theme::get();
         let cancel = btn_secondary("clear-lh-cancel", "Cancel").on_mouse_down(
             MouseButton::Left,
             cx.listener(|this, _e, _w, cx| {
@@ -852,29 +931,13 @@ impl Kyde {
                 || "this project".to_string(),
                 |n| n.to_string_lossy().into_owned(),
             );
-        div()
-            .size_full()
-            .flex()
-            .flex_col()
-            .gap_3()
-            .p_4()
-            .font_family(ui)
-            .text_size(px(theme::get().ui_font_size + 1.0))
-            .child(div().text_color(t.text).child(SharedString::from(format!(
-                "Clear local history for “{project}”?"
-            ))))
-            .child(
-                div()
-                    .flex_1()
-                    .text_color(t.secondary_text)
-                    .text_size(px(theme::get().ui_font_size))
-                    .child(
-                        "Deletes every snapshot and timeline event Kyde has recorded for \
-                         this project. Git history is not touched. Can't be undone.",
-                    ),
-            )
-            .child(ui::modal_footer().child(cancel).child(confirm))
-            .into_any_element()
+        ui::confirm_body(
+            format!("Clear local history for “{project}”?"),
+            "Deletes every snapshot and timeline event Kyde has recorded for this project. \
+             Git history is not touched. Can't be undone.",
+        )
+        .child(ui::modal_footer().child(cancel).child(confirm))
+        .into_any_element()
     }
 
     /// The Local History window's context-menu items — `render_context_menu`'s match
@@ -1092,6 +1155,9 @@ impl Kyde {
                     selected,
                     name,
                     t.text,
+                    None,
+                    None,
+                    false,
                     None,
                     None,
                     move |this, _e, _w, cx| {

--- a/src/views/modals.rs
+++ b/src/views/modals.rs
@@ -328,8 +328,6 @@ impl Kyde {
     /// Body of the "Clear Data & Restart" confirmation modal window. Destructive: wipes the
     /// whole config dir and restarts.
     pub(crate) fn render_clear_data_body(&mut self, cx: &mut Context<Self>) -> gpui::AnyElement {
-        let ui = theme::font::UI_FAMILY;
-        let t = theme::get();
         let cancel = btn_secondary("clear-cancel", "Cancel").on_mouse_down(
             MouseButton::Left,
             cx.listener(|this, _e, _w, cx| this.close_modal_window(ModalKind::ClearData, cx)),
@@ -338,27 +336,13 @@ impl Kyde {
             MouseButton::Left,
             cx.listener(|this, _e, _w, cx| this.do_clear_data(cx)),
         );
-        div()
-            .size_full()
-            .flex()
-            .flex_col()
-            .gap_3()
-            .p_4()
-            .font_family(ui)
-            .text_size(px(theme::get().ui_font_size + 1.0))
-            .child(div().text_color(t.text).child("Clear all data & restart?"))
-            .child(
-                div()
-                    .flex_1()
-                    .text_color(t.secondary_text)
-                    .text_size(px(theme::get().ui_font_size))
-                    .child(
-                        "Uninstalls all language plugins and clears cached settings (keymap, \
-                         theme, recent projects, preferences). Kyde will restart. Can't be undone.",
-                    ),
-            )
-            .child(ui::modal_footer().child(cancel).child(confirm))
-            .into_any_element()
+        ui::confirm_body(
+            "Clear all data & restart?",
+            "Uninstalls all language plugins and clears cached settings (keymap, theme, \
+             recent projects, preferences). Kyde will restart. Can't be undone.",
+        )
+        .child(ui::modal_footer().child(cancel).child(confirm))
+        .into_any_element()
     }
 
     /// Font specimen viewer: each bundled family at every available weight, previewing a

--- a/src/views/rollback.rs
+++ b/src/views/rollback.rs
@@ -65,6 +65,9 @@ impl Kyde {
                     name_color,
                     Some(checked),
                     None,
+                    false,
+                    None,
+                    None,
                     // Click toggles the row's checkbox (folders expand); the diff is reached
                     // by right-click → View Diff, not a plain click.
                     move |this, _e, _w, cx| {


### PR DESCRIPTION
Implements every open enhancement/bug issue except Windows/Linux support (#10).

## Issues
- **#68** — rename folders (not just files); repoints open tabs, selection, and the expanded set across the moved subtree.
- **#66** — non-git projects hide all git actions (branch chip, git menu items, commit/history) and the git views explain why, with an **Initialize Git Repository** button (`git init`).
- **#65** — drag files/folders onto folders in the tree with the target folder highlighted; guards no-op and into-own-subtree drops.
- **#67** — Cut/Copy/Paste in the tree (context menu + ⌘X/⌘C/⌘V), plus pasting Finder-copied files, pasting clipboard **image data** as an image file, and dragging files in from Finder (per-folder highlight). Context menu grouped with icons + subtle dividers.
- **#64** — extract reusable modal/dialog/empty-state UI helpers, removing duplicated hand-rolled `div` chains.

## Notable internals
- Renames/moves now recorded in Local History (old path tombstoned, new path labelled).
- New `kyde-git::Repo::init`; new `kyde-ui` `panel`/`menu_divider` helpers + tree drag/drop plumbing.
- macOS `NSPasteboard` file-URL reads via objc2 (new `platform::clipboard`).

## Testing
New unit/smoke tests for every feature. `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -D warnings`, and `cargo test --workspace` all green (90 binary tests + all crates).

Closes #68, #66, #65, #67, #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)