### PR TITLE
feat(changelog): add a What's New window mirroring GitHub releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ divider.rs    unified divider dragging (Divider enum + geometry + drag methods).
 
 # ── views/ — per-feature modules (render_* + logic for one feature) ──
 browse  tabs  commit  diff_view  push  branch  history  finder  find  rollback
-file_ops  modals  onboarding  projects_view  notifications  terminal_panel
+file_ops  modals  onboarding  projects_view  notifications  terminal_panel  changelog
 
 # ── widgets/ — gpui-coupled widgets (own Entities/Elements) ──
 editor/  mdview.rs  terminal.rs  remote_img.rs
@@ -87,7 +87,8 @@ kyde-diff     FileDiff::compute() → line Hunks + word ranges; stats();
               partial_new_content(); hunk_patch(). (similar)
 kyde-tree     Tree::build/visible — the file-tree model. (std)
 kyde-markdown Block/Span markdown model for the preview. (pulldown-cmark)
-kyde-update   GitHub release check + self-update download/swap. (thiserror: UpdateError, serde_json)
+kyde-update   GitHub release check + self-update download/swap, plus the changelog feed
+              (`release_notes`/`parse_releases`). (thiserror: UpdateError, serde_json)
 kyde-config   keymap + plugins + projects: config/persistence (JSON, XDG). (serde)
 kyde-color    tiny RGBA `Color` POD shared by theme/syntax. Zero deps; optional `gpui`
               feature → `From<Color>` for gpui `Rgba/Hsla/Fill/Background` (UI layer only).
@@ -771,6 +772,21 @@ async via `cx.spawn`). The OS folder dialog has no initial-dir field in gpui 0.2
 Launch: `kyde` shell function in `~/.zshrc` runs the newest of
 `target/{release,debug}/kyde`, args passed through (bare = Projects view).
 (`gs` is ghostscript — not aliased.)
+
+## Changelog window (issue #71 — src/views/changelog.rs + kyde-update)
+"What's New" mirrors the GitHub Releases page in-app: Kyde ▸ **What's New…** (menu action
+`OpenChangelog`), the ⌘⇧A palette, or the **What's new** link on the update banner →
+`ModalKind::Changelog`. Left = one row per release (`v<version>`, date, `current` badge on the
+running version); right = that release's notes rendered by the selectable `mdview::MarkdownView`,
+with an "Open on GitHub" link. Data = `kyde_update::release_notes()` (`GET /releases?per_page=50`,
+`KYDE_RELEASES_FEED_URL`-overridable like the update feed) fetched **off the UI thread on first
+open only**; `parse_releases` is pure + unit-tested (drafts skipped, newest-version first, CRLF
+normalised, `published_at` trimmed to `YYYY-MM-DD`). A failed fetch keeps the window useful:
+error text + **Retry** + a link to the releases page. State = `ChangelogView` (`changelog` on
+`Kyde`); `set_changelog` applies a fetch result (the test/shot seam — no network needed). Smoke
+test: `changelog_lists_releases_and_shows_their_notes`. Debug shot: `KYDE_SHOT=changelog`
+(seeds fixed notes, so it's offline/deterministic; `KYDE_SHOT_RELEASES=<feed dump>` renders a
+real feed instead).
 
 ## Sort ops (issues #43/#41 — Sort Lines + Sort Object Keys)
 Right-clicking the editor pane (the `MenuTarget::EditorGit` menu) offers, above the git

--- a/crates/kyde-update/src/lib.rs
+++ b/crates/kyde-update/src/lib.rs
@@ -68,6 +68,10 @@ fn io_err(operation: impl Into<String>) -> impl FnOnce(std::io::Error) -> Update
 /// GitHub "latest release" API for this repo.
 const DEFAULT_FEED: &str = "https://api.github.com/repos/kyle-ssg/kyde/releases/latest";
 
+/// GitHub "all releases" API for this repo — the changelog window's feed (issue #71).
+const DEFAULT_RELEASES_FEED: &str =
+    "https://api.github.com/repos/kyle-ssg/kyde/releases?per_page=50";
+
 /// A release newer than what's running.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Release {
@@ -83,6 +87,27 @@ pub struct Release {
     pub sha256_url: String,
     /// Release page URL — the fallback when we can't swap in place (dev binary / no asset).
     pub page_url: String,
+}
+
+/// One published release, as shown in the changelog window (issue #71) — the GitHub
+/// Releases page mirrored in-app. Unlike [`Release`] (the self-update target) this carries
+/// the human-facing notes and is kept for *every* version, not just newer ones.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseNote {
+    /// Normalised numeric version, e.g. "2.5.0".
+    pub version: String,
+    /// Raw tag, e.g. "kyde-v2.5.0".
+    pub tag: String,
+    /// Release title (GitHub's `name`); falls back to the tag when unset.
+    pub title: String,
+    /// Release notes, markdown as published.
+    pub body: String,
+    /// Publication date as `YYYY-MM-DD` (empty when GitHub reports none).
+    pub date: String,
+    /// Release page URL — the "Open on GitHub" link.
+    pub page_url: String,
+    /// Whether GitHub flagged this as a pre-release.
+    pub prerelease: bool,
 }
 
 /// Version the running app reports — env override (dev/testing) else the compiled crate version.
@@ -187,6 +212,77 @@ pub fn parse_feed(body: &str, current: &str) -> Option<Release> {
         sha256_url,
         page_url,
     })
+}
+
+/// Where the changelog window reads its release list from (`KYDE_RELEASES_FEED_URL`
+/// overrides it — a `file://` fixture works, same dev seam as [`feed_url`]).
+fn releases_feed_url() -> String {
+    std::env::var("KYDE_RELEASES_FEED_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_RELEASES_FEED.to_string())
+}
+
+/// Fetch every published release, newest first — the changelog window's data (issue #71).
+/// Network I/O: run it off the UI thread. `Err` = network/HTTP failure (the caller shows a
+/// retry + an "Open on GitHub" link).
+pub fn release_notes() -> Result<Vec<ReleaseNote>> {
+    let body = curl_text(&releases_feed_url())?;
+    Ok(parse_releases(&body))
+}
+
+/// Pure feed → release notes, so the changelog is unit-testable without the network.
+/// Drafts are skipped (they aren't public), entries are sorted newest-version first, and a
+/// tag with no numeric version sorts last rather than being dropped.
+pub fn parse_releases(body: &str) -> Vec<ReleaseNote> {
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
+        return Vec::new();
+    };
+    // A single-release feed (the `latest` endpoint) parses too — treat it as a one-element list.
+    let items: Vec<&serde_json::Value> = match json.as_array() {
+        Some(a) => a.iter().collect(),
+        None if json.is_object() => vec![&json],
+        None => return Vec::new(),
+    };
+    let mut out: Vec<ReleaseNote> = items
+        .into_iter()
+        .filter(|r| !r["draft"].as_bool().unwrap_or(false))
+        .filter_map(|r| {
+            let tag = r["tag_name"].as_str().unwrap_or("").trim().to_string();
+            if tag.is_empty() {
+                return None;
+            }
+            let title = r["name"]
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&tag)
+                .to_string();
+            Some(ReleaseNote {
+                version: norm(&tag),
+                title,
+                // GitHub sends CRLF in release bodies; the markdown parser is happier without.
+                body: r["body"].as_str().unwrap_or("").replace("\r\n", "\n"),
+                date: r["published_at"]
+                    .as_str()
+                    .or_else(|| r["created_at"].as_str())
+                    .unwrap_or("")
+                    .chars()
+                    .take(10)
+                    .collect(),
+                page_url: r["html_url"].as_str().unwrap_or("").to_string(),
+                prerelease: r["prerelease"].as_bool().unwrap_or(false),
+                tag,
+            })
+        })
+        .collect();
+    // Newest first; unparseable tags sink to the bottom (keeps real versions ordered).
+    out.sort_by(|a, b| {
+        parse_semver(&b.tag)
+            .unwrap_or((0, 0, 0))
+            .cmp(&parse_semver(&a.tag).unwrap_or((0, 0, 0)))
+    });
+    out
 }
 
 /// Filename tokens that identify a build for `arch` (Rust's `std::env::consts::ARCH`).
@@ -575,6 +671,47 @@ mod tests {
             Some("https://x/kyde-macos.zip")
         );
         assert_eq!(pick_asset_url(&shipping, "x86_64").as_deref(), Some(intel));
+    }
+
+    /// The changelog feed (issue #71): drafts dropped, newest version first, CRLF cleaned,
+    /// dates trimmed to `YYYY-MM-DD`, missing `name` falling back to the tag.
+    #[test]
+    fn parse_releases_orders_newest_first_and_skips_drafts() {
+        let feed = r#"[
+            { "tag_name": "kyde-v2.4.0", "name": "2.4.0", "body": "old\r\nnotes",
+              "published_at": "2026-05-01T10:11:12Z", "html_url": "u24", "prerelease": false },
+            { "tag_name": "kyde-v2.10.0", "name": "", "body": "newest",
+              "published_at": "2026-07-01T00:00:00Z", "html_url": "u210" },
+            { "tag_name": "kyde-v2.5.0", "name": "2.5.0", "body": "mid",
+              "published_at": "2026-06-02T00:00:00Z", "html_url": "u25", "prerelease": true },
+            { "tag_name": "kyde-v9.9.9", "name": "draft", "body": "x", "draft": true }
+        ]"#;
+        let rs = parse_releases(feed);
+        // Numeric order (2.10 > 2.5), draft excluded.
+        assert_eq!(
+            rs.iter().map(|r| r.version.as_str()).collect::<Vec<_>>(),
+            ["2.10.0", "2.5.0", "2.4.0"]
+        );
+        assert_eq!(rs[0].title, "kyde-v2.10.0", "no name → tag as the title");
+        assert_eq!(
+            rs[2].body, "old\nnotes",
+            "CRLF normalised for the md parser"
+        );
+        assert_eq!(rs[2].date, "2026-05-01");
+        assert!(rs[1].prerelease);
+        assert_eq!(rs[0].page_url, "u210");
+    }
+
+    #[test]
+    fn parse_releases_tolerates_junk_and_single_objects() {
+        assert!(parse_releases("not json").is_empty());
+        assert!(parse_releases("[]").is_empty());
+        // Tagless entries are skipped; a lone object (the `latest` endpoint) still parses.
+        assert!(parse_releases(r#"[{ "body": "x" }]"#).is_empty());
+        let one = parse_releases(r#"{ "tag_name": "v1.2.3", "body": "b" }"#);
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].version, "1.2.3");
+        assert_eq!(one[0].date, "", "no timestamp → empty date, not a panic");
     }
 
     #[test]

--- a/scripts/screenshots.sh
+++ b/scripts/screenshots.sh
@@ -178,7 +178,7 @@ shoot() {
     # rollback / plugins-window / merge / local-history open a second (modal) window;
     # the rest have one.
     local need=1
-    case "$name" in rollback|plugins-window|merge|merge-conflicts|local-history) need=2 ;; esac
+    case "$name" in rollback|plugins-window|merge|merge-conflicts|local-history|changelog) need=2 ;; esac
 
     local tries=0 count=0
     while [ $tries -lt 80 ]; do
@@ -318,6 +318,7 @@ run_one() {
         merge)            shoot_until merge            merge.png            region KYDE_SHOT_REPO="$MERGE_REPO" ;;
         merge-conflicts)  shoot_until merge-conflicts  merge-conflicts.png  region KYDE_SHOT_REPO="$MERGE_REPO" ;;
         terminal)         shoot_until terminal         terminal.png         window ;;
+        changelog)        shoot_until changelog        changelog.png        region ;;
         fps)              shoot_until fps              fps.png              window KYDE_SHOT_FILE="$LOCK_REL" ;;
         welcome-gif)      shoot_welcome_gif ;;
         *) echo "unknown shot: $1"; exit 2 ;;

--- a/src/app.rs
+++ b/src/app.rs
@@ -278,6 +278,8 @@ impl Kyde {
             merge: MergeView::new(cx),
             compare_win: None,
             compare: CompareView::new(cx),
+            changelog_win: None,
+            changelog: ChangelogView::new(cx),
             local_history_win: None,
             lh: LocalHistoryView::new(cx),
             fs_watcher: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,14 @@ actions!(
 // Native menu bar actions.
 actions!(
     kyde_menu,
-    [Quit, ToggleFps, ClearData, OpenPlugins, OpenProject]
+    [
+        Quit,
+        ToggleFps,
+        ClearData,
+        OpenPlugins,
+        OpenProject,
+        OpenChangelog
+    ]
 );
 
 /// The native macOS menu bar: the app menu (Settings/Plugins/Quit) + a File menu with
@@ -166,6 +173,7 @@ fn app_menus(recents: &Recents) -> Vec<Menu> {
             items: vec![
                 MenuItem::action("Settings…", OpenKeymap),
                 MenuItem::action("Plugins…", OpenPlugins),
+                MenuItem::action("What's New…", OpenChangelog),
                 MenuItem::action("Toggle FPS Monitor", ToggleFps),
                 MenuItem::separator(),
                 MenuItem::action("Clear Data & Restart…", ClearData),
@@ -432,6 +440,7 @@ enum PaletteAction {
     NavForward,
     LocalHistory,
     ClearLocalHistory,
+    Changelog,
 }
 
 /// Action-finder entries: (label, action, keymap-action name for the shortcut
@@ -467,6 +476,7 @@ const PALETTE: &[(&str, PaletteAction, &str)] = &[
     ("Settings / Keymap", PaletteAction::Settings, "open_keymap"),
     ("Manage Plugins", PaletteAction::Plugins, ""),
     ("Preview Fonts", PaletteAction::Fonts, ""),
+    ("What's New (Changelog)", PaletteAction::Changelog, ""),
 ];
 
 /// What a right-click context menu was opened on.
@@ -1482,6 +1492,10 @@ struct Kyde {
     clear_data_win: Option<gpui::WindowHandle<ModalWindow>>,
     /// "Clear Local History" confirmation — wipes the open project's snapshot store.
     clear_lh_win: Option<gpui::WindowHandle<ModalWindow>>,
+    /// "What's New" changelog — a native modal window mirroring GitHub Releases (issue #71).
+    changelog_win: Option<gpui::WindowHandle<ModalWindow>>,
+    /// Its state: the fetched release list, the selected row, and the markdown pane.
+    changelog: ChangelogView,
     /// Settings — a native modal window with a category sidebar (Appearance/Keymap/…).
     settings_win: Option<gpui::WindowHandle<ModalWindow>>,
     /// Which Settings category the sidebar has selected.
@@ -1613,6 +1627,36 @@ enum ModalKind {
     LocalHistory,
     /// "Clear Local History" confirmation (destructive — wipes the project's store).
     ClearLocalHistory,
+    /// "What's New": the published releases + their notes (issue #71).
+    Changelog,
+}
+
+/// Changelog-window state (issue #71): the GitHub release list, which one is showing, and
+/// the markdown pane its notes render into. Fetched lazily on first open (see
+/// `views/changelog.rs`); a failure leaves `error` set and the list empty.
+struct ChangelogView {
+    /// Published releases, newest first.
+    notes: Vec<update::ReleaseNote>,
+    /// Index into `notes` of the release being shown.
+    selected: usize,
+    /// A fetch is in flight (shows "Loading releases…").
+    loading: bool,
+    /// Why the last fetch failed / why there's nothing to show (shows Retry + a GitHub link).
+    error: Option<String>,
+    /// The selected release's notes, rendered as selectable markdown.
+    body: Entity<mdview::MarkdownView>,
+}
+
+impl ChangelogView {
+    fn new(cx: &mut Context<Kyde>) -> Self {
+        Self {
+            notes: Vec::new(),
+            selected: 0,
+            loading: false,
+            error: None,
+            body: cx.new(|cx| mdview::MarkdownView::new("", None, cx)),
+        }
+    }
 }
 
 /// Compare-two-files state (issue #42): the chosen paths, the computed diff, and
@@ -1808,6 +1852,7 @@ impl Render for ModalWindow {
             ModalKind::Compare => k.render_compare_body(kcx),
             ModalKind::LocalHistory => k.render_local_history_body(kcx),
             ModalKind::ClearLocalHistory => k.render_clear_local_history_body(kcx),
+            ModalKind::Changelog => k.render_changelog_body(kcx),
         });
         div()
             .track_focus(&self.focus)
@@ -2695,6 +2740,42 @@ fn apply_shot(view: &mut Kyde, name: &str, window: &mut Window, cx: &mut Context
             ) {
                 view.open_compare(PathBuf::from(a), PathBuf::from(b), cx);
             }
+        }
+        // The "What's New" changelog window (issue #71). Seeded with fixed release notes so
+        // the shot is deterministic and needs no network; `KYDE_SHOT_RELEASES=<file>` renders
+        // a real GitHub feed dump instead.
+        "changelog" => {
+            let seeded = std::env::var("KYDE_SHOT_RELEASES")
+                .ok()
+                .and_then(|f| std::fs::read_to_string(f).ok())
+                .map(|body| update::parse_releases(&body))
+                .filter(|r| !r.is_empty())
+                .unwrap_or_else(|| {
+                    ["2.5.0", "2.4.0", "2.3.0"]
+                        .iter()
+                        .enumerate()
+                        .map(|(i, v)| update::ReleaseNote {
+                            version: (*v).to_string(),
+                            tag: format!("kyde-v{v}"),
+                            title: format!("Kyde {v}"),
+                            body: String::from(
+                                "## Features\n\n* **compare:** side-by-side compare of any \
+                                 two files ([#42](https://github.com/kyle-ssg/kyde/issues/42))\n\
+                                 * **local history:** per-file snapshots independent of git\n\n\
+                                 ## Bug Fixes\n\n* **editor:** keep the caret visible when \
+                                 folding a region\n* **tree:** drop deleted paths from the \
+                                 file tree\n",
+                            ),
+                            date: format!("2026-0{}-14", 7 - i),
+                            page_url: format!("https://github.com/kyle-ssg/kyde/releases/tag/v{v}"),
+                            prerelease: false,
+                        })
+                        .collect()
+                });
+            // Seed BEFORE opening: `open_changelog` only fetches when the list is empty, so
+            // this keeps the shot offline and deterministic (no live feed racing it in).
+            view.set_changelog(Ok(seeded), cx);
+            view.open_changelog(cx);
         }
         // Browse a Rust file with ⌘ "held" over an import — the link underlines
         // (issue #26). Uses the debug hover forcer since shots can't hold keys.
@@ -4460,6 +4541,47 @@ mod gpui_smoke_tests {
                 assert!(k.lh.events.is_empty(), "any open timeline empties");
                 let store = k.lh.store.clone().unwrap();
                 assert_eq!(store.lock().unwrap().event_count(), 0, "store wiped");
+            })
+            .unwrap();
+    }
+
+    /// Changelog window (issue #71): opening it spawns the native window; a fetch result
+    /// populates the version list, selects the newest, and pushes its notes into the
+    /// markdown pane; selecting an older release swaps the notes. A failed fetch keeps the
+    /// window usable (error text + Retry), never a blank pane.
+    #[gpui::test]
+    fn changelog_lists_releases_and_shows_their_notes(cx: &mut TestAppContext) {
+        let (handle, _dir) = boot(cx);
+        handle.update(cx, |k, _w, cx| k.open_changelog(cx)).unwrap();
+        cx.run_until_parked(); // the native window opens on a spawned task
+        handle
+            .update(cx, |k, _w, cx| {
+                assert!(k.changelog_win.is_some(), "changelog window opens");
+                let note = |v: &str, body: &str| update::ReleaseNote {
+                    version: v.into(),
+                    tag: format!("kyde-v{v}"),
+                    title: format!("Kyde {v}"),
+                    body: body.into(),
+                    date: "2026-07-01".into(),
+                    page_url: format!("https://example.com/{v}"),
+                    prerelease: false,
+                };
+                k.set_changelog(
+                    Ok(vec![note("2.5.0", "# new stuff"), note("2.4.0", "# old")]),
+                    cx,
+                );
+                assert_eq!(k.changelog.notes.len(), 2);
+                assert_eq!(k.changelog.selected, 0, "newest release shown first");
+                assert!(k.changelog.error.is_none());
+                assert_eq!(k.changelog.body.read(cx).source(), "# new stuff");
+
+                k.select_changelog(1, cx);
+                assert_eq!(k.changelog.body.read(cx).source(), "# old");
+
+                // Fetch failure → an error to show, and the retry path is armed.
+                k.set_changelog(Err("network is down".into()), cx);
+                assert_eq!(k.changelog.error.as_deref(), Some("network is down"));
+                assert!(!k.changelog.loading);
             })
             .unwrap();
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -323,6 +323,7 @@ impl Render for Kyde {
             .on_action(cx.listener(Self::act_confirm))
             .on_action(cx.listener(Self::act_clear_data))
             .on_action(cx.listener(Self::act_open_plugins))
+            .on_action(cx.listener(Self::act_open_changelog))
             .on_action(cx.listener(Self::act_find))
             .on_action(cx.listener(Self::act_replace))
             .on_action(cx.listener(Self::find_next))

--- a/src/views/changelog.rs
+++ b/src/views/changelog.rs
@@ -1,0 +1,304 @@
+//! Changelog window (issue #71) — the project's GitHub Releases mirrored in-app: a version
+//! list on the left, that release's notes rendered as markdown on the right. Data comes from
+//! `kyde_update::release_notes` (fetched off the UI thread, `KYDE_RELEASES_FEED_URL`-overridable);
+//! a fetch failure shows a Retry + an "Open on GitHub" fallback. Crate-root child module.
+
+use crate::*;
+
+impl Kyde {
+    /// Kyde menu "What's New…" / palette "What's New (Changelog)": open the changelog as a
+    /// native modal window and (re)load the release feed.
+    pub(crate) fn open_changelog(&mut self, cx: &mut Context<Self>) {
+        self.open_modal_window(ModalKind::Changelog, "What's New", 860.0, 620.0, cx);
+        if self.changelog.notes.is_empty() {
+            self.load_changelog(cx);
+        }
+    }
+
+    /// Menu-bar action wrapper for [`Self::open_changelog`].
+    pub(crate) fn act_open_changelog(
+        &mut self,
+        _: &OpenChangelog,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_changelog(cx);
+    }
+
+    /// Fetch the release list on a background thread (network I/O never on the UI thread) and
+    /// hand the result to [`Self::set_changelog`].
+    pub(crate) fn load_changelog(&mut self, cx: &mut Context<Self>) {
+        if self.changelog.loading {
+            return;
+        }
+        self.changelog.loading = true;
+        self.changelog.error = None;
+        cx.notify();
+        cx.spawn(async move |this, cx| {
+            let fetched = cx
+                .background_executor()
+                .spawn(async move { update::release_notes().map_err(|e| e.to_string()) })
+                .await;
+            this.update(cx, |this, cx| this.set_changelog(fetched, cx))
+                .ok();
+        })
+        .detach();
+    }
+
+    /// Apply a fetch result: keep the notes, select the newest, and push its body into the
+    /// markdown pane. Split out from the fetch so tests can drive the window without network.
+    pub(crate) fn set_changelog(
+        &mut self,
+        fetched: std::result::Result<Vec<update::ReleaseNote>, String>,
+        cx: &mut Context<Self>,
+    ) {
+        self.changelog.loading = false;
+        match fetched {
+            Ok(notes) if notes.is_empty() => {
+                self.changelog.notes = notes;
+                self.changelog.error = Some("No releases published yet.".into());
+            }
+            Ok(notes) => {
+                self.changelog.notes = notes;
+                self.changelog.error = None;
+                self.changelog.selected = 0;
+            }
+            Err(e) => self.changelog.error = Some(e),
+        }
+        self.sync_changelog_body(cx);
+        cx.notify();
+    }
+
+    /// Show release `i`'s notes.
+    pub(crate) fn select_changelog(&mut self, i: usize, cx: &mut Context<Self>) {
+        if i >= self.changelog.notes.len() {
+            return;
+        }
+        self.changelog.selected = i;
+        self.sync_changelog_body(cx);
+        cx.notify();
+    }
+
+    /// Push the selected release's markdown into the preview entity (no base dir — the notes
+    /// are remote, so relative image paths have nothing local to resolve against).
+    fn sync_changelog_body(&mut self, cx: &mut Context<Self>) {
+        let md = self
+            .changelog
+            .notes
+            .get(self.changelog.selected)
+            .map(|r| r.body.clone())
+            .unwrap_or_default();
+        self.changelog
+            .body
+            .update(cx, |v, cx| v.set_text(&md, None, cx));
+    }
+
+    /// Body of the "What's New" modal window (hosted by `ModalWindow`, native titlebar).
+    pub(crate) fn render_changelog_body(&mut self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let t = theme::get();
+        let ui = theme::font::UI_FAMILY;
+        let ui_fs = px(t.ui_font_size);
+        let running = update::current_version();
+
+        // ── left: one row per published release ──
+        let rows: Vec<gpui::AnyElement> = self
+            .changelog
+            .notes
+            .iter()
+            .enumerate()
+            .map(|(i, r)| {
+                let sel = i == self.changelog.selected;
+                let title: SharedString = format!("v{}", r.version).into();
+                let meta: SharedString = match (r.date.as_str(), r.prerelease) {
+                    ("", false) => String::new(),
+                    ("", true) => "pre-release".into(),
+                    (d, false) => d.to_string(),
+                    (d, true) => format!("{d} · pre-release"),
+                }
+                .into();
+                // Mark the version the user is actually running.
+                let current = r.version == running;
+                ui::picker::row(("changelog-row", i), sel, t.bg_light)
+                    .flex()
+                    .flex_col()
+                    .gap_0p5()
+                    .mx(px(4.0))
+                    .px_3()
+                    .py_1p5()
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap_2()
+                            .child(div().text_color(t.text).child(title))
+                            .when(current, |d| {
+                                d.child(
+                                    div()
+                                        .px_1p5()
+                                        .rounded_md()
+                                        .bg(t.bg_mid)
+                                        .text_size(px(t.ui_font_size - 2.0))
+                                        .text_color(t.line_number)
+                                        .child("current"),
+                                )
+                            }),
+                    )
+                    .when(!meta.is_empty(), |d| {
+                        d.child(
+                            div()
+                                .text_size(px(t.ui_font_size - 1.0))
+                                // `line_number` grey vanishes against the selected-row fill.
+                                .text_color(if sel { t.secondary_text } else { t.line_number })
+                                .child(meta),
+                        )
+                    })
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _e, _w, cx| this.select_changelog(i, cx)),
+                    )
+                    .into_any_element()
+            })
+            .collect();
+
+        let list = div()
+            .id("changelog-list")
+            .flex_none()
+            .w(px(200.0))
+            .h_full()
+            .overflow_y_scroll()
+            .flex()
+            .flex_col()
+            .gap(px(2.0))
+            .py_2()
+            .border_r(px(1.0))
+            .border_color(t.divider)
+            .children(rows);
+
+        // ── right: the selected release's notes (or the loading / error state) ──
+        let selected = self.changelog.notes.get(self.changelog.selected);
+        let header = selected.map(|r| {
+            let heading: SharedString = if r.title.trim().is_empty() {
+                format!("v{}", r.version)
+            } else {
+                r.title.clone()
+            }
+            .into();
+            let url = r.page_url.clone();
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .justify_between()
+                .gap_3()
+                .px_4()
+                .py_2()
+                .border_b(px(1.0))
+                .border_color(t.divider)
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .truncate()
+                        .text_color(t.text)
+                        .font_weight(FontWeight::BOLD)
+                        .child(heading),
+                )
+                .when(!url.is_empty(), |d| {
+                    d.child(
+                        div()
+                            .id("changelog-open-github")
+                            .flex_none()
+                            .cursor_pointer()
+                            .text_color(t.primary)
+                            .hover(|s| s.text_color(t.text))
+                            .child("Open on GitHub")
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |_this, _e, _w, cx| cx.open_url(&url)),
+                            ),
+                    )
+                })
+        });
+
+        let content: gpui::AnyElement = if self.changelog.loading {
+            self.changelog_message("Loading releases…", None, cx)
+        } else if let Some(err) = self.changelog.error.clone() {
+            self.changelog_message(
+                SharedString::from(format!("Couldn't load the changelog — {err}")),
+                Some(()),
+                cx,
+            )
+        } else {
+            div()
+                .id("changelog-body")
+                .size_full()
+                .overflow_y_scroll()
+                .p_4()
+                .child(self.changelog.body.clone())
+                .into_any_element()
+        };
+
+        div()
+            .size_full()
+            .flex()
+            .flex_row()
+            .font_family(ui)
+            .text_size(ui_fs)
+            .text_color(t.text)
+            .child(list)
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .h_full()
+                    .flex()
+                    .flex_col()
+                    .children(header)
+                    .child(content),
+            )
+            .into_any_element()
+    }
+
+    /// Centered status text for the notes pane; `retry` adds a Retry button + a link to the
+    /// releases page (the error state — the window is still useful offline).
+    fn changelog_message(
+        &self,
+        msg: impl Into<SharedString>,
+        retry: Option<()>,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let t = theme::get();
+        div()
+            .size_full()
+            .flex()
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap_3()
+            .text_color(t.line_number)
+            .child(msg.into())
+            .when(retry.is_some(), |d| {
+                d.child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_2()
+                        .child(btn_primary("changelog-retry", "Retry").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _e, _w, cx| this.load_changelog(cx)),
+                        ))
+                        .child(
+                            btn_secondary("changelog-releases", "Open on GitHub").on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|_this, _e, _w, cx| {
+                                    cx.open_url("https://github.com/kyle-ssg/kyde/releases");
+                                }),
+                            ),
+                        ),
+                )
+            })
+            .into_any_element()
+    }
+}

--- a/src/views/finder.rs
+++ b/src/views/finder.rs
@@ -562,6 +562,9 @@ impl Kyde {
             PaletteAction::Plugins => {
                 self.open_modal_window(ModalKind::Plugins, "Language Plugins", 520.0, 560.0, cx);
             }
+            PaletteAction::Changelog => {
+                self.open_changelog(cx);
+            }
             PaletteAction::Fonts => {
                 self.open_modal_window(ModalKind::Fonts, "Fonts", 760.0, 620.0, cx);
             }

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -3,6 +3,7 @@
 //! shared `ui` toolkit and the controller core in app.rs/render.rs.
 mod branch;
 mod browse;
+mod changelog;
 mod commit;
 mod compare;
 mod diff_view;

--- a/src/views/modals.rs
+++ b/src/views/modals.rs
@@ -448,6 +448,7 @@ impl Kyde {
             ModalKind::Compare => &mut self.compare_win,
             ModalKind::LocalHistory => &mut self.local_history_win,
             ModalKind::ClearLocalHistory => &mut self.clear_lh_win,
+            ModalKind::Changelog => &mut self.changelog_win,
         }
     }
 

--- a/src/views/notifications.rs
+++ b/src/views/notifications.rs
@@ -67,6 +67,21 @@ impl Kyde {
                     .child(badge)
                     .child(msg),
             )
+            // The release notes for what's being offered (issue #71) — same window as the
+            // Kyde ▸ What's New… menu item.
+            .child(
+                div()
+                    .id("update-whats-new")
+                    .flex_none()
+                    .cursor_pointer()
+                    .text_color(t.primary)
+                    .hover(|s| s.text_color(t.text))
+                    .child("What's new")
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _e, _w, cx| this.open_changelog(cx)),
+                    ),
+            )
             .child(
                 btn_primary("update-now", action_label)
                     .when(updating, |d| d.opacity(0.6))

--- a/src/widgets/mdview.rs
+++ b/src/widgets/mdview.rs
@@ -106,6 +106,13 @@ impl MarkdownView {
         }
     }
 
+    /// The markdown currently rendered (what the last `set_text` accepted) — the seam the
+    /// changelog smoke test reads, so it's test-only.
+    #[cfg(test)]
+    pub fn source(&self) -> &str {
+        &self.src
+    }
+
     /// Re-parse only if the source actually changed (preserves selection otherwise). The
     /// base dir can change without the text changing (switching between two files of equal
     /// content is unlikely, but keep it in sync regardless).


### PR DESCRIPTION
Closes #71.

## What

A native **What's New** window that mirrors the project's GitHub Releases page in-app — version list on the left, that release's notes rendered as selectable markdown on the right.

<img width="900" alt="What's New window — version list left, rendered release notes right" src="https://github.com/user-attachments/assets/placeholder" />

* Left column: one row per published release (`v<version>`, date, a `current` badge on the running version, pre-release marked).
* Right pane: the release body via the existing `mdview::MarkdownView`, plus an **Open on GitHub** link.
* Entry points: **Kyde ▸ What's New…**, the ⌘⇧A palette, and a **What's new** link on the update-available banner.

## How

* `kyde-update` gains `ReleaseNote`, `release_notes()` (`GET /releases?per_page=50`, overridable with `KYDE_RELEASES_FEED_URL` — the same dev seam as the update feed) and the pure `parse_releases`: drafts skipped, newest version first (numeric, so 2.10 > 2.5), CRLF normalised for the markdown parser, `published_at` trimmed to `YYYY-MM-DD`.
* Fetched **off the UI thread, on first open only**. A failed fetch keeps the window useful — error text + **Retry** + a link to the releases page, never a blank pane.
* State lives in `ChangelogView`; `set_changelog` applies a fetch result, which is also the test/screenshot seam (no network needed).

## Tests

* `parse_releases` unit tests: ordering/draft/CRLF/date behaviour, and junk-tolerance (bad JSON, tagless entries, a single-object feed).
* `changelog_lists_releases_and_shows_their_notes` smoke test: window opens, newest release selected, notes land in the markdown pane, selecting an older release swaps them, a failed fetch surfaces the error.
* `KYDE_SHOT=changelog` debug shot, seeded with fixed notes so it stays offline and deterministic (`KYDE_SHOT_RELEASES=<feed dump>` renders a real feed instead).
* `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -D warnings` + `cargo test --workspace` all green; verified manually against the live GitHub feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)