### PR TITLE
feat(instance): restrict Kyde to one instance, opening later launches as project tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ file_ops  modals  onboarding  projects_view  notifications  terminal_panel
 editor/  mdview.rs  terminal.rs  remote_img.rs
 
 # ── platform/ — small OS utils (no gpui) ──
-clipboard.rs  scratch.rs  shellcmd.rs
+clipboard.rs  scratch.rs  shellcmd.rs  instance.rs (single-instance socket)
 
 # ── workspace crates (pure Rust, no Kyde; see crates/<name>) ──
 kyde-git      Repo: discover/status/numstat/base_content/working_content/stage/unstage/
@@ -772,6 +772,22 @@ Launch: `kyde` shell function in `~/.zshrc` runs the newest of
 `target/{release,debug}/kyde`, args passed through (bare = Projects view).
 (`gs` is ghostscript — not aliased.)
 
+## Single instance (issue #72 — src/platform/instance.rs + main.rs)
+Every open project is already a **tab** (`open_projects`), so a second `kyde <path>` from the
+terminal must NOT start a second app — it hands the path to the running one, which opens it as
+another project tab and comes forward. Mechanism = a **unix domain socket** (`$TMPDIR/kyde-
+<hash>.sock`, hash = `USER|XDG_CONFIG_HOME` so users/config profiles never collide; a `TMPDIR`
+too deep for `sun_path`'s ~104 bytes falls back to `/tmp` with the dir folded into the hash —
+`socket_path_in`, unit-tested, this is a real bind failure not a hypothetical). `main()` calls
+`instance::try_send` BEFORE `Application::new()`: delivered → `return` (no window, no gpui
+init, ~30ms); nothing listening → we're the instance and `instance::listen` binds after the
+main window opens. The accept thread can't touch gpui entities, so it only forwards a
+`Request` (`Open(path)` / `Activate`) over a `futures::mpsc` channel to a foreground pump —
+the terminal `EventProxy` / fs-watcher pattern — which calls `open_project` + `activate_window`.
+A socket left behind by a crash/SIGTERM is detected (connect fails) and unlinked before the
+rebind; a clean exit unlinks it via `Guard`'s `Drop`. **Opt-out**: `KYDE_SINGLE_INSTANCE=0`,
+and any `KYDE_SHOT` run (the screenshot suite launches instances back to back).
+
 ## Sort ops (issues #43/#41 — Sort Lines + Sort Object Keys)
 Right-clicking the editor pane (the `MenuTarget::EditorGit` menu) offers, above the git
 commands: **Sort Lines** when the selection spans ≥2 lines OR the caret sits in a
@@ -834,7 +850,7 @@ Opening a project lands in **Browse (code) view**, not git — `open_project`/`n
 - gpui but **Kyde-agnostic**, its own crate: `kyde-ui` (the reusable toolkit — buttons, badge,
   tree row, …; depends only on gpui + kyde-theme).
 - Plain Rust, still in the binary (small OS utils, not yet crated): `platform/{scratch,
-  shellcmd}.rs`.
+  shellcmd,instance}.rs`.
 - gpui UI in the binary: core shell `main.rs`/`app.rs`/`render.rs`/`divider.rs`; the `views/`
   feature modules; the `widgets/` (editor, mdview, terminal, remote_img).
   Compile on gpui 0.2.2.

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ use widgets::terminal;
 
 // ── small OS utilities ──
 mod platform;
-use platform::{clipboard as os_clipboard, scratch, shellcmd};
+use platform::{clipboard as os_clipboard, instance, scratch, shellcmd};
 
 // ── workspace crates, aliased back to their old module names ──
 use kyde_config::keymap;
@@ -2827,6 +2827,20 @@ fn main() {
         .and_then(|p| Repo::discover(&p).ok())
         .map(|repo| repo.root().to_path_buf());
 
+    // Single instance (issue #72): every open project is already a tab, so a second
+    // `kyde <path>` hands the path to the running Kyde (which opens it as another tab and
+    // comes forward) and exits here, before any window is created. Nothing listening → we
+    // are the instance, and take the socket over below.
+    let guarded = instance::enabled();
+    if guarded {
+        let req = initial
+            .clone()
+            .map_or(instance::Request::Activate, instance::Request::Open);
+        if instance::try_send(&req) {
+            return;
+        }
+    }
+
     let (km, first_run) = Keymap::load();
 
     let app = Application::new().with_assets(Assets);
@@ -2910,6 +2924,36 @@ fn main() {
                 .detach();
             })
             .ok();
+
+        // Become the instance later launches talk to (issue #72). The socket thread can't
+        // touch gpui entities, so it only forwards over a channel to this foreground pump —
+        // the terminal `EventProxy` / fs-watcher pattern. The guard lives in the task, so the
+        // socket is unlinked when the app goes away.
+        if guarded {
+            let (tx, mut rx) = futures::channel::mpsc::unbounded::<instance::Request>();
+            if let Some((guard, _thread)) = instance::listen(move |req| {
+                let _ = tx.unbounded_send(req);
+            }) {
+                cx.spawn(async move |cx| {
+                    let _guard = guard;
+                    while let Some(req) = futures::StreamExt::next(&mut rx).await {
+                        let ok = window.update(cx, |view, window, cx| {
+                            if let instance::Request::Open(path) = req {
+                                view.open_project(path, cx);
+                                window.focus(&view.focus_handle(cx));
+                            }
+                            // Either way the user asked for Kyde — raise it.
+                            window.activate_window();
+                            cx.activate(true);
+                        });
+                        if ok.is_err() {
+                            break; // main window gone — stop pumping
+                        }
+                    }
+                })
+                .detach();
+            }
+        }
     });
 }
 

--- a/src/platform/instance.rs
+++ b/src/platform/instance.rs
@@ -1,0 +1,244 @@
+//! Single-instance guard (issue #72). Kyde already shows every open project as a tab, so a
+//! second `kyde <path>` from the terminal shouldn't start a second app — it should hand the
+//! path to the running one, which opens it as another project tab and comes to the front.
+//!
+//! Mechanism: a unix domain socket in the temp dir. First launch binds it and accepts
+//! connections on a background thread, forwarding each payload over a channel to the UI
+//! thread. A later launch connects, writes the resolved project path (or nothing, meaning
+//! "just activate"), and exits before opening a window. A socket left behind by a crash is
+//! detected (connect fails) and replaced.
+//!
+//! Opt-out: `KYDE_SINGLE_INSTANCE=0` (or a `KYDE_SHOT` screenshot run) keeps the old
+//! one-process-per-launch behaviour. The socket name also carries the config directory, so
+//! two instances pointed at different `XDG_CONFIG_HOME`s (the screenshot suite, dev
+//! sandboxes) are separate "profiles" and never steal each other's launches.
+
+use std::io::{Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+
+/// What a second launch asked the running instance to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Request {
+    /// Open (or switch to) this project.
+    Open(PathBuf),
+    /// No path given (bare `kyde`) — just bring the running window forward.
+    Activate,
+}
+
+/// Whether the single-instance guard is active for this launch. Off when explicitly disabled
+/// or when driving a screenshot (the suite launches instances back to back).
+pub(crate) fn enabled() -> bool {
+    !matches!(
+        std::env::var("KYDE_SINGLE_INSTANCE").as_deref(),
+        Ok("0" | "false" | "off")
+    ) && std::env::var_os("KYDE_SHOT").is_none()
+}
+
+/// Encode a request as the one-line wire payload.
+pub(crate) fn encode(req: &Request) -> String {
+    match req {
+        Request::Open(p) => format!("open\t{}\n", p.display()),
+        Request::Activate => "activate\n".to_string(),
+    }
+}
+
+/// Decode a wire payload. Unknown verbs and empty paths degrade to `Activate` — the worst a
+/// malformed message can do is raise the window.
+pub(crate) fn decode(payload: &str) -> Request {
+    let line = payload.lines().next().unwrap_or("").trim_end();
+    match line.split_once('\t') {
+        Some(("open", p)) if !p.is_empty() => Request::Open(PathBuf::from(p)),
+        _ => Request::Activate,
+    }
+}
+
+/// FNV-1a — a stable, dependency-free hash for the profile part of the socket name.
+fn fnv64(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x1000_0000_01b3);
+    }
+    h
+}
+
+/// A unix socket path can't exceed `sun_path` (104 bytes on macOS) — bind fails outright
+/// with "path must be shorter than `SUN_LEN`". Leave margin below it.
+const SUN_MAX: usize = 100;
+
+/// The socket this launch talks on: one per user + config dir ("profile"), so separate users
+/// on a shared `/tmp` and separate `XDG_CONFIG_HOME`s never collide.
+pub(crate) fn socket_path() -> PathBuf {
+    let dir = std::env::var_os("TMPDIR").map_or_else(|| PathBuf::from("/tmp"), PathBuf::from);
+    let profile = format!(
+        "{}|{}",
+        std::env::var("USER").unwrap_or_default(),
+        std::env::var("XDG_CONFIG_HOME").unwrap_or_default()
+    );
+    socket_path_in(&dir, &profile)
+}
+
+/// Pure socket-path rule (the seam the tests drive): `<dir>/kyde-<profile hash>.sock`, or —
+/// when that would blow `sun_path`, as a deep sandbox/CI `TMPDIR` does — `/tmp` with the
+/// directory folded into the hash, so distinct temp dirs still get distinct sockets.
+fn socket_path_in(dir: &Path, profile: &str) -> PathBuf {
+    let p = dir.join(format!("kyde-{:x}.sock", fnv64(profile)));
+    if p.as_os_str().len() <= SUN_MAX {
+        return p;
+    }
+    let scoped = format!("{}|{profile}", dir.display());
+    PathBuf::from("/tmp").join(format!("kyde-{:x}.sock", fnv64(&scoped)))
+}
+
+/// Try to hand this launch to an already-running instance. `true` = delivered (the caller
+/// should exit without opening a window); `false` = nothing listening, so we're the instance.
+/// A stale socket (owner died) is removed here so the [`listen`] that follows can bind.
+pub(crate) fn try_send(req: &Request) -> bool {
+    send_to(&socket_path(), req)
+}
+
+/// [`try_send`] against an explicit socket path (the seam the tests drive).
+fn send_to(sock: &Path, req: &Request) -> bool {
+    if let Ok(mut stream) = UnixStream::connect(sock) {
+        // A running instance answered; if the write fails it's mid-shutdown — report
+        // undelivered so we take over rather than exiting silently.
+        return stream.write_all(encode(req).as_bytes()).is_ok() && stream.flush().is_ok();
+    }
+    // Nothing accepting: either no instance, or a socket file a crash left behind.
+    if sock.exists() {
+        let _ = std::fs::remove_file(sock);
+    }
+    false
+}
+
+/// Owns the listening socket; unlinks it on drop so a clean exit leaves nothing behind.
+pub(crate) struct Guard {
+    path: PathBuf,
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Become the single instance: bind the socket and accept launches on a background thread,
+/// invoking `on_request` for each. The callback runs on that thread — it must only forward
+/// (the gpui entities aren't `Send`). `None` = we couldn't bind (permissions, sandbox), in
+/// which case the caller just runs as a normal, unguarded instance.
+pub(crate) fn listen(
+    on_request: impl Fn(Request) + Send + 'static,
+) -> Option<(Guard, std::thread::JoinHandle<()>)> {
+    let path = socket_path();
+    let listener = UnixListener::bind(&path).ok()?;
+    let handle = std::thread::Builder::new()
+        .name("kyde-instance".into())
+        .spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buf = String::new();
+                // Bound the read: a peer that never closes must not wedge the thread, and a
+                // launch payload is one short line.
+                if Read::by_ref(&mut stream)
+                    .take(4096)
+                    .read_to_string(&mut buf)
+                    .is_ok()
+                {
+                    on_request(decode(&buf));
+                }
+            }
+        })
+        .ok()?;
+    Some((Guard { path }, handle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payloads_round_trip_and_degrade_safely() {
+        let open = Request::Open(PathBuf::from("/Users/x/my repo"));
+        assert_eq!(decode(&encode(&open)), open, "spaces survive the wire");
+        assert_eq!(decode(&encode(&Request::Activate)), Request::Activate);
+        // Anything unexpected raises the window rather than opening a bogus project.
+        assert_eq!(decode(""), Request::Activate);
+        assert_eq!(decode("open\t"), Request::Activate);
+        assert_eq!(decode("nonsense\t/tmp"), Request::Activate);
+        assert_eq!(
+            decode("open\t/tmp/p\nextra junk\n"),
+            Request::Open(PathBuf::from("/tmp/p")),
+            "only the first line is the request"
+        );
+    }
+
+    /// Different config homes = different profiles = different sockets (so the screenshot
+    /// suite and a dev instance never hijack each other), and the path always fits
+    /// `sun_path` — a deep `TMPDIR` (sandbox, CI) falls back to `/tmp` instead of failing
+    /// to bind with "path must be shorter than `SUN_LEN`".
+    #[test]
+    fn socket_path_is_per_profile_and_always_bindable() {
+        let short = socket_path_in(Path::new("/var/folders/ab/T"), "kyle|");
+        assert!(
+            short.starts_with("/var/folders/ab/T"),
+            "normal TMPDIR is used"
+        );
+        assert_ne!(
+            short,
+            socket_path_in(Path::new("/var/folders/ab/T"), "kyle|/tmp/other-cfg"),
+            "distinct config homes get distinct sockets"
+        );
+
+        let deep = Path::new(
+            "/private/tmp/claude-501/-Users-someone-project/0123456789abcdef-0123-4567/scratchpad",
+        );
+        let long = socket_path_in(deep, "kyle|");
+        assert!(long.starts_with("/tmp"), "deep TMPDIR falls back to /tmp");
+        assert!(long.as_os_str().len() <= SUN_MAX, "must fit sun_path");
+        assert_ne!(
+            long,
+            socket_path_in(
+                Path::new("/some/other/very/very/very/very/very/very/very/very/very/long/tmp"),
+                "kyle|"
+            ),
+            "the fallback still separates temp dirs"
+        );
+    }
+
+    /// The real handshake: a listener takes a launch, and a send with nothing listening
+    /// reports false (and clears a stale socket file).
+    #[test]
+    fn a_second_launch_is_delivered_to_the_listener() {
+        let dir = std::env::temp_dir().join(format!("kyde-inst-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let sock = dir.join("k.sock");
+
+        // Nothing listening yet: a stale file is cleaned up, delivery fails.
+        std::fs::write(&sock, b"stale").expect("write stale socket");
+        assert!(!send_to(&sock, &Request::Activate));
+        assert!(!sock.exists(), "stale socket removed so we can bind");
+
+        let listener = UnixListener::bind(&sock).expect("bind");
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                let mut buf = String::new();
+                let mut stream = stream;
+                if stream.read_to_string(&mut buf).is_ok() {
+                    let _ = tx.send(decode(&buf));
+                }
+            }
+        });
+
+        let want = Request::Open(PathBuf::from("/Users/x/proj"));
+        assert!(send_to(&sock, &want), "listener accepts the launch");
+        let got = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("request forwarded");
+        assert_eq!(got, want);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,4 +1,5 @@
 //! Small OS-integration utilities (no gpui): shell-command install, scratch paths.
 pub(crate) mod clipboard;
+pub(crate) mod instance;
 pub(crate) mod scratch;
 pub(crate) mod shellcmd;


### PR DESCRIPTION
Closes #72.

## What

Every open project is already a tab, so a second `kyde <path>` from the terminal shouldn't start a second app. It now hands the path to the running instance, which opens it as another **project tab** and comes forward. Bare `kyde` just raises the window.

## How

* `src/platform/instance.rs`: a unix domain socket at `$TMPDIR/kyde-<hash>.sock`, hashed over `USER|XDG_CONFIG_HOME` so separate users and config profiles never collide.
* A `TMPDIR` too deep for `sun_path` (~104 bytes — sandboxed/CI temp dirs hit this) falls back to `/tmp`, with the directory folded into the hash so temp dirs stay distinct. Without this, `bind` fails outright with *"path must be shorter than SUN_LEN"* and the guard silently does nothing — found while testing, not hypothetical.
* `main()` tries to deliver the launch **before** `Application::new()`, so a forwarded launch exits in ~30ms having created no window and initialised no gpui. Nothing listening → we're the instance, and bind after the main window opens.
* The accept thread can't touch gpui entities, so it only forwards a `Request` (`Open(path)` / `Activate`) over a `futures::mpsc` channel to a foreground pump — the terminal `EventProxy` / fs-watcher pattern — which calls `open_project` + `activate_window`.
* A socket left behind by a crash or SIGTERM is detected (connect fails) and unlinked before the rebind; a clean exit unlinks it on `Drop`.
* **Opt-out**: `KYDE_SINGLE_INSTANCE=0`, and automatically off under `KYDE_SHOT` so the screenshot suite can keep launching instances back to back.

## Tests

* Payload round-trip + safe degradation (malformed/unknown verbs raise the window rather than opening a bogus project).
* The socket-path rule, including the long-`TMPDIR` fallback and per-profile separation.
* A real listener handshake over a socket, including stale-socket cleanup.
* Manually verified end to end: second launch exits 0 in ~30ms, one process remains, the running window gains the new project tab and comes forward; stale-socket recovery and bare-`kyde` activation both work.
* `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -D warnings` + `cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)