### PR TITLE
docs: correct the docs against what actually ships

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ about the `.clone()`s.
 - **If a feature adds a lot of bloat, it should be a plugin**, not core. Language
   highlighting is the model: gated behind a Cargo feature, off by default at the
   margins, collapses gracefully when absent. See `Cargo.toml [features]` and
-  `src/plugins.rs`.
+  `crates/kyde-config/src/plugins.rs`.
 - **Speed is the whole point.** Anything on a per-keystroke, per-frame, or
   per-file-select hot path must stay fast. If you add such a path, add a `perf_*`
   guard test (see below).
@@ -32,7 +32,8 @@ in `.github/workflows/build.yml` for the exact `apt` list.
 ```sh
 cargo build                 # debug build
 cargo run -- /path/to/repo  # run against any git repo (bare = Projects view)
-cargo test                  # logic + perf guard tests
+cargo test --workspace      # logic + perf guard tests (see below — plain `cargo test`
+                            # only covers the binary, not the crates/)
 ```
 
 ## Before you open a PR
@@ -41,9 +42,16 @@ CI runs these and will fail the PR otherwise, so run them locally first:
 
 ```sh
 cargo fmt --all                         # then commit the result
-cargo clippy --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --all
 ```
+
+Match the clippy flags exactly — `--workspace` lints all eleven crates rather than just
+the binary, and `--all-features` reaches the `cfg`-gated grammar / terminal /
+remote-image code; a narrower local run passes while CI fails. CI runs these on both
+`ubuntu-latest` and `macos-15` with `RUSTFLAGS: -D warnings`, so plain rustc warnings
+fail too — including in the macOS-only `#[cfg(target_os = "macos")]` paths a Linux run
+can't see.
 
 A trim build is also checked in CI — if you touch the feature/grammar wiring,
 verify it still compiles:
@@ -64,10 +72,17 @@ machine. Skip a hook with `--no-verify` if you must.
 
 ## Tests
 
-- Plain-Rust modules (`git.rs`, `diff.rs`, `highlight.rs`, `theme.rs`, `keymap.rs`,
-  `plugins.rs`, `tree.rs`, `shellcmd.rs`, …) carry unit tests in their own
-  `#[cfg(test)] mod tests` — this is a bin crate with no lib target, so tests live
-  in-module, not in `tests/`.
+- The pure-logic code lives in workspace crates under `crates/` (`kyde-git`,
+  `kyde-diff`, `kyde-syntax`, `kyde-theme`, `kyde-config`, `kyde-tree`,
+  `kyde-local-history`, …); each carries unit tests in its own `#[cfg(test)] mod tests`,
+  plus doctests on the key pure entry points. Run one in isolation with
+  `cargo test -p kyde-syntax`.
+- The binary's own tests (including the headless-gpui smoke tests) live in-module too —
+  it has no lib target, so `tests/` can't reach its `pub fn`s.
+- Run the lot with `cargo test --workspace`. A bare `cargo test` builds only the root
+  package (the binary), silently skipping every crate above. Note that under a slim
+  feature set the `kyde-syntax` tests for grammars you didn't compile will fail — use
+  `--workspace` or `-p kyde-syntax` (whose own default is all grammars) for a true green.
 - **Perf guards** are named `perf_*` (run just them with `cargo test perf`). They
   push a representative-sized input through a hot path and assert it finishes under
   a deliberately loose budget — the goal is catching algorithmic blowups (accidental

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ Built from scratch on gpui, borrowing patterns from existing editors but not the
 
 ## Theme
 
-A hand-tuned dark palette, configurable at runtime via `~/.config/kyde/theme.json`. A
-built-in **Kyde Light** palette ships too — switch in Settings.
+A hand-tuned dark palette, configurable at runtime via `~/.config/kyde/theme.json`.
+Six built-in palettes ship — **Kyde Dark**, **Kyde Light**, and colour-vision-deficiency
+variants of each (**Red–Green** and **Blue–Yellow**, which separate the diff/syntax poles
+by lightness instead of hue) — switch in Settings.
 
 <p align="center">
   <img src="assets/screenshots/light.png" alt="Kyde Light theme — the same side-by-side diff rendered in the built-in light palette" width="900">
@@ -59,9 +61,12 @@ built-in **Kyde Light** palette ships too — switch in Settings.
 * **Text editor** — selection, undo/redo, copy/cut/paste, Tab/Shift-Tab indent, ⌘-backspace, line numbers, current-line highlight, IME, auto-save.
 * **Find & replace** — `⌘F` find (`⌘G`/`⇧⌘G` to cycle), `⌘R` replace.
 * **Editor tabs** that scroll and follow the active file.
-* **Image preview** for PNG/JPG/GIF/WebP.
+* **Image preview** for PNG/JPG/GIF/WebP/BMP/ICO/AVIF/TIFF.
 * **Syntax highlighting** via tree-sitter, installed on demand from a built-in **Language Plugins** manager. Packs: **TypeScript/TSX, JavaScript, Rust, JSON, Markdown, Shell, CSS, SCSS, YAML, TOML, Python, HTML, Go, R, LaTeX** — plus always-on `.env` and `.gitignore` highlighters, and a **Font preview** plugin. Each pack is also a Cargo feature, so a build can ship only the grammars it wants ([details](#build)).
 * **Code folding** for grammar-backed languages.
+* **Error highlighting** — wavy red squiggles under parse errors, on by default for every installed pack, opt-out per pack.
+* **⌘-click navigation** — ⌘-click an import to open the file it points at, a symbol to jump to its definition (same file, or the file it was imported from). Rust, TypeScript/TSX, JavaScript, Python.
+* **Sort Lines** (`⌥⌘L`) and **Sort Object Keys** (`⌥⌘S`) — a line sort inside a JSON/JS/TS object delegates to the key sort, so entries move with their commas.
 * **Markdown preview** — a live rendered pane alongside the editor.
 
 <p align="center">
@@ -79,7 +84,7 @@ built-in **Kyde Light** palette ships too — switch in Settings.
 ### Terminal
 
 * **Embedded multi-tab terminal** — a real PTY-backed shell (alacritty's VTE engine),
-  bottom-docked, toggled with `⌃\``. Full color, scrollback, resize, multiple tabs.
+  bottom-docked, toggled with ``⌃` ``. Full color, scrollback, resize, multiple tabs.
 * **Mouse select + copy** (`⌘C`), **paste** (`⌘V`, bracketed-paste aware), **`⌘`-click URLs**.
 * History (`↑`), tab-completion, line-editing all work — it's your real shell.
 * Optional: drop it entirely with `--no-default-features` (the `terminal` Cargo feature)
@@ -94,12 +99,20 @@ built-in **Kyde Light** palette ships too — switch in Settings.
 * **Commit view**: changed-files list + an editable side-by-side diff — base on the left, live working copy on the right, both highlighted.
 * **Stage / revert** per hunk from the center gutter, or whole files; commit via the message box.
 * **Rollback** in a native window — checkbox tree, optional deletion of added files, right-click for diff.
-* **Push** when ahead of upstream (status-bar button + context menu).
+* **Push / Pull / Fetch** — status-bar chips that appear when you're ahead or behind upstream, plus the context menu.
 * **Branch switcher** — searchable tree, `/` as folders, Recent / Local roots, ahead/behind counts per branch.
+* **Worktree switcher** — a chip listing every linked worktree with its branch and changed-file count; switching restores that worktree's UI state, and the branch popup jumps to a worktree rather than failing a checkout that's already checked out elsewhere.
+* **Compare two files** — ⌘-click two files in the tree → right-click → **Compare Selected** (or right-click a tab → **Compare with Current Tab**) for a side-by-side compare in a native window, with a `«` `»` gutter that applies a hunk in either direction.
 * **Merge** — right-click a branch to merge it into the current one. Conflicts open a native two-stage resolver: a conflicts list (what each side did, Accept Yours / Accept Theirs / Merge…), then a 3-pane merge view — yours | result | theirs — with per-change apply/ignore gutters, "apply non-conflicting changes", Compare Contents pairs, and whitespace-ignoring diffs.
 * **History** — commit log for any branch, with the selected commit's changed files and a read-only diff that compares vs the parent, latest, or your local working tree.
 * **Local History** — per-file snapshots independent of git (saves, external changes, and markers before every destructive op). A timeline + snapshot ↔ current diff per file or folder, a changed-since files panel, per-hunk restore, and revert for one file, a folder, or everything since a snapshot — every revert is itself recorded. Configurable retention, clearable, or off entirely.
-* **File management** from the tree — New File, Rename, Delete (with confirm).
+* **File management** from the tree — New File / Directory / Scratch, Rename (files *and* folders, repointing open tabs across the moved subtree), Delete (with confirm), Cut / Copy / Paste (`⌘X`/`⌘C`/`⌘V`, including files copied in Finder and clipboard image data), drag & drop within the tree or in from Finder, and Reveal in Finder.
+* **Non-git folders work too** — file management and editing are plain filesystem ops; git actions hide themselves and offer an **Initialize Git Repository** button instead.
+* **Live** — a filesystem watcher (`notify`/FSEvents) refreshes git status and local history when files change outside Kyde, on top of the window-refocus refresh. `.git`-internal churn is filtered so Kyde's own git commands don't spin it.
+
+<p align="center">
+  <img src="assets/screenshots/worktrees.png" alt="Worktree switcher — a popup listing every linked worktree with its branch and changed-file count, the active one ticked" width="900">
+</p>
 
 <p align="center">
   <img src="assets/screenshots/rollback.png" alt="Rollback in a native window — checkbox tree of changes over the diff" width="900">
@@ -125,6 +138,7 @@ built-in **Kyde Light** palette ships too — switch in Settings.
 
 * **Go to File** (`⌘⇧O` / `⌘P`) and **Find Action** (`⌘⇧A`) fuzzy finders.
 * **Find in Files** (`⌘⇧F`) — full-text content search across the repo (`git grep`), jump straight to a match.
+* **Back / Forward** (`⌘⌥←` / `⌘⌥→`) through visited files, IDE-style.
 * **Scratch files** — throwaway buffers under a "Scratches" folder.
 * **Breadcrumbs** in the status bar.
 
@@ -135,7 +149,10 @@ built-in **Kyde Light** palette ships too — switch in Settings.
 ### Look & feel
 
 * **Islands layout** — rounded panels, draggable dividers, activity rail, native title bar (double-click to zoom), status bar.
-* **Native menu bar** — Settings, FPS monitor toggle, Quit.
+* **Native menu bar** — Settings, Plugins, What's New, FPS monitor toggle, Clear Data & Restart, Quit, plus a File menu with Open and Recent Projects (also on the Dock icon's right-click menu).
+* **What's New** — the project's GitHub releases mirrored in-app: version list on the left, that release's notes rendered on the right.
+* **In-app updates** — a banner when a newer release exists; **Update & Relaunch** downloads and swaps the running `.app` in place (or opens the release page when not running from a bundle).
+* **Single instance** — a second `ky <path>` hands the project to the running app as another tab and brings it forward instead of starting a second process (`KYDE_SINGLE_INSTANCE=0` opts out).
 * **App icon** from the bundled logo.
 
 ### Keymap & configuration
@@ -169,12 +186,16 @@ Default shortcuts (WebStorm → VSCode):
 
 * Go to File: `⌘⇧O` → `⌘P`
 * Find Action: `⌘⇧A`
-* Find / Replace in file: `⌘F` / `⌘R`
+* Find in Files: `⌘⇧F`
+* Find / Replace in file: `⌘F` / `⌘R` (`⌘G` / `⇧⌘G` to cycle)
 * Save: `⌘S`
 * Commit: `⌘K` → `⌘⏎`
 * Commit view: `⌘9` → `⌃⇧G`
 * Browse view: `⌘1` → `⌘⇧E`
+* Back / Forward: `⌘⌥←` / `⌘⌥→`
+* Sort Lines / Sort Object Keys: `⌥⌘L` / `⌥⌘S`
 * New Scratch: `⌘⇧N`
+* Toggle terminal: ``⌃` ``
 * Settings: `⌘,`
 
 ## Build
@@ -182,9 +203,12 @@ Default shortcuts (WebStorm → VSCode):
 Needs Rust 1.96+ and (on macOS) Apple's Metal Toolchain, which gpui uses to compile its shaders — if a clean machine errors with "missing Metal Toolchain", run `xcodebuild -downloadComponent MetalToolchain`.
 
 ```sh
-cargo build --release          # full — every language grammar baked in (default)
-cargo test                     # logic, perf guards, and headless-gpui smoke tests
+cargo build --release             # full — every language grammar baked in (default)
+cargo test --workspace            # logic, perf guards, and headless-gpui smoke tests
 ```
+
+`--workspace` matters: the root package is the binary, so a bare `cargo test` skips the
+library crates under `crates/` where most of the logic tests live.
 
 Each language pack is a Cargo feature, so unused grammars can be dropped from the binary entirely (smaller image + resident RAM):
 
@@ -205,8 +229,8 @@ Guarded by `perf_*` time-budget tests, headless-gpui smoke tests (render every s
 ## Known limitations / next
 
 * **Prebuilt releases are macOS-only.** I develop on macOS and wouldn't actively test Linux/Windows, so I only ship a signed + notarized macOS build rather than binaries I can't stand behind. The code itself is cross-platform — gpui runs on all three, and Linux/Windows packaging already exists in `scripts/` (just unwired from the release). Re-enabling them is a **good first issue** for a contributor who runs those platforms. Until then, Linux/Windows users can `cargo build --release`.
-* No soft-wrap or caret-follow scrolling yet. The editor uses a flat `String`; a rope-based buffer comes later for very large edits.
-* Live file watching (`notify`/FSEvents) refreshes git status + local history when files change outside Kyde, on top of the window-refocus refresh. `.git`-internal churn is filtered so our own git commands don't spin it.
+* No soft-wrap in the file editor (long lines scroll horizontally; the commit box does wrap). The editor holds a flat `String` and undo is whole-buffer snapshots — a rope-based buffer comes later for very large edits.
+* No scrollback search in the terminal.
 
 ## Contributing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,9 +14,12 @@ Kyde follows [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`.
    version from the commits since the last release.
 3. When you're ready to ship, **merge the release PR**. release-please then creates
    the `vX.Y.Z` git tag and the GitHub Release.
-4. In the same workflow run, the `build` job packages the three platform artifacts
-   (macOS `.app` zip, Linux AppImage, Windows `.exe` zip) and attaches them to the
-   release.
+4. In the same workflow run, the `build` job packages the macOS artifacts — an
+   Apple-Silicon `kyde-macos.zip` and an Intel `kyde-macos-x86_64.zip`, each with a
+   `.sha256` — Developer ID signs, notarizes and staples them (a no-op that leaves the
+   ad-hoc signature if the signing secrets aren't set), and attaches them to the release.
+   Linux and Windows packaging exists in `scripts/`, but its matrix entries and package
+   steps are **commented out** in `release.yml`; uncomment both to revive a platform.
 
 That's it. Cutting a release = merging one PR.
 
@@ -32,15 +35,16 @@ The commit messages on `main` decide the version bump:
 | `chore:`, `docs:`, `refactor:`, `test:`, `ci:` | none | housekeeping, no release |
 
 A breaking change is anything that breaks a config format (theme/keymap/plugins/
-projects JSON), the `ky` CLI, or removes a feature. While Kyde is `0.x` SemVer makes
-no compatibility promise; the practical convention is `0.MINOR` may break and
-`0.MINOR.PATCH` does not. Save `1.0.0` for when the config formats and the
-commit/diff workflow are stable enough to promise it.
+projects/history JSON), the `ky` CLI, or removes a feature. Kyde is past `1.0`, so a
+`feat!:` / `BREAKING CHANGE:` really does mean the next MAJOR — reach for it only when a
+config format or the `ky` CLI genuinely changes shape.
 
-The version lives in exactly one place release-please owns: `Cargo.toml` `version`
-(mirrored into the binary via `CARGO_PKG_VERSION`, the macOS Info.plist, and the
-Windows `.exe` metadata). The git tag always matches it — release-please guarantees
-the lockstep that used to be manual.
+release-please owns the version in two places, kept in lockstep: the root `Cargo.toml`
+`[package].version` (its `rust` strategy needs a literal string there) and
+`[workspace.package].version`, which the member crates inherit — the latter updated via
+the `extra-files` entry in `release-please-config.json`. The version is mirrored into the
+binary through `CARGO_PKG_VERSION`, the macOS `Info.plist`, and the Windows `.exe`
+metadata. The git tag always matches it.
 
 ## After a release
 
@@ -54,8 +58,9 @@ If you ever need to release without release-please (e.g. the action is down), no
 that pushing a tag by hand will **not** trigger the build — the `build` job in
 `release.yml` is gated on release-please's `release_created` output, and tags created
 with the default token don't fire it. So a manual release means doing the packaging
-yourself too: bump `Cargo.toml`, update `CHANGELOG.md`, push a `vX.Y.Z` tag and create
-the GitHub Release yourself, then run the `build` matrix locally (the bundle scripts:
-`scripts/bundle-macos.sh`, `scripts/bundle-linux.sh`, and a `cargo build --release` on
-Windows) and `gh release upload` each artifact. The automated path is strongly
-preferred.
+yourself too: bump both `version` fields in `Cargo.toml` (and `Cargo.lock`), update
+`CHANGELOG.md`, push a `vX.Y.Z` tag and create the GitHub Release yourself, then build
+the artifacts locally (`TARGET=aarch64-apple-darwin ./scripts/bundle-macos.sh`, then
+again for `x86_64-apple-darwin`, zipping each `dist/Kyde.app` as `kyde-macos.zip` /
+`kyde-macos-x86_64.zip`) and `gh release upload` each one. Locally built apps are
+ad-hoc-signed, not notarized. The automated path is strongly preferred.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Supported versions
 
-Kyde is pre-1.0 and ships from `main`. Security fixes land on `main` and in the
-next tagged release. Older tagged releases are not separately patched.
+Kyde ships from `main`, and only the latest release is supported. Security fixes land
+on `main` and in the next tagged release; older tags are not separately patched.
 
 ## Reporting a vulnerability
 
@@ -23,14 +23,22 @@ credit (if you'd like one) are published with the release.
 Kyde is a local desktop app. Things worth a report:
 
 - **Shell-out injection.** Kyde drives git by shelling out to the `git` binary
-  (`src/git.rs`). A repo path, branch name, file name, or commit message that can
-  break argument boundaries and run an unintended command is in scope.
+  (`crates/kyde-git/src/lib.rs`). A repo path, branch name, file name, or commit
+  message that can break argument boundaries and run an unintended command is in
+  scope.
 - **Path traversal / writes outside the open project** — file editing, save, and
   rollback (which deletes files) should never touch paths outside the selected
   repo.
 - **Config parsing** — the JSON config files under `~/.config/kyde/` (theme,
-  keymap, plugins, projects) are user-editable; a crafted file causing memory
-  unsafety is in scope (panics that are merely a crash are lower priority).
+  keymap, plugins, projects, history) are user-editable, as is the local-history
+  store under `~/.local/share/kyde/`; a crafted file causing memory unsafety is in
+  scope (panics that are merely a crash are lower priority).
+- **The in-app updater** — it downloads a release archive and swaps the running
+  `.app` in place (`crates/kyde-update`). Anything letting an attacker substitute
+  that payload is in scope.
+- **The single-instance socket** — a later launch hands a project path to the
+  running instance over a unix socket in the temp dir (`src/platform/instance.rs`).
+  A local process able to make Kyde open or act on a path it shouldn't is in scope.
 - **Dependency advisories** — CI runs `cargo-deny` against RustSec, but a flagged
   advisory we've missed is welcome.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>Kyde — fast native Git client &amp; diff editor</title>
-  <meta name="description" content="A fast native Git client and diff editor in Rust. Instant startup, side-by-side diffs with word-level highlighting and hunk staging, an IDE-grade commit view. macOS, Linux and Windows.">
+  <meta name="description" content="A fast native Git client and diff editor in Rust. Instant startup, side-by-side diffs with word-level highlighting and hunk staging, an IDE-grade commit view. Prebuilt for macOS; builds from source on Linux and Windows.">
   <link rel="canonical" href="https://kyle-ssg.github.io/Kyde/">
 
   <!-- Open Graph / social card -->
@@ -149,13 +149,23 @@
       </div>
       <div class="card">
         <span class="ic">⎇</span>
-        <h3>Branches &amp; rollback</h3>
-        <p>Searchable branch switcher, commit, push, and a native rollback window with a checkbox tree of changes.</p>
+        <h3>Branches, merge &amp; rollback</h3>
+        <p>Searchable branch and worktree switchers, commit, push/pull/fetch, a 3-pane conflict resolver, and a native rollback window with a checkbox tree of changes.</p>
+      </div>
+      <div class="card">
+        <span class="ic">🕘</span>
+        <h3>Local history</h3>
+        <p>Per-file snapshots independent of git — a timeline, a before/after diff, and per-hunk or whole-file revert for anything you edited, deleted or rolled back.</p>
+      </div>
+      <div class="card">
+        <span class="ic">▮</span>
+        <h3>Built-in terminal</h3>
+        <p>A real PTY-backed multi-tab shell docked at the bottom, with full colour, selection and copy/paste. Your shell, your prompt.</p>
       </div>
       <div class="card">
         <span class="ic">🎨</span>
-        <h3>Familiar dark theme</h3>
-        <p>A hand-tuned dark palette that feels at home to anyone who's lived in a modern IDE. Configurable at runtime.</p>
+        <h3>Familiar themes</h3>
+        <p>Hand-tuned dark and light palettes that feel at home to anyone who's lived in a modern IDE, plus colour-vision-deficiency variants. Configurable at runtime.</p>
       </div>
       <div class="card">
         <span class="ic">⌨️</span>
@@ -168,14 +178,16 @@
   <section class="wrap">
     <h2>Install</h2>
     <div class="platforms">
-      <span class="pill">macOS</span>
-      <span class="pill">Linux</span>
-      <span class="pill">Windows</span>
+      <span class="pill">macOS — prebuilt</span>
+      <span class="pill">Linux — from source</span>
+      <span class="pill">Windows — from source</span>
     </div>
-    <pre><code># macOS — download kyde-macos.zip from Releases, then:
-xattr -dr com.apple.quarantine /Applications/Kyde.app
+    <pre><code># macOS — download from Releases and drag Kyde.app to /Applications:
+#   kyde-macos.zip          Apple Silicon
+#   kyde-macos-x86_64.zip   Intel
+# The build is Developer ID signed and notarized — no quarantine dance.
 
-# or build from source
+# or build from source (any platform)
 cargo build --release</code></pre>
   </section>
 


### PR DESCRIPTION
## What

An accuracy pass over `README.md`, `CONTRIBUTING.md`, `RELEASING.md`, `SECURITY.md` and the GitHub Pages landing page, checking every factual claim against the code. Docs only — no code touched.

### Wrong, now fixed

| Claim | Reality |
|---|---|
| `cargo test` runs the test suite | The root package is the binary, so a bare `cargo test` skips every crate under `crates/`. Now `cargo test --workspace`, with the reason spelled out (README + CONTRIBUTING). |
| CONTRIBUTING: `cargo clippy --all-targets -- -D warnings` | CI runs `--workspace --all-targets --all-features`. The documented command could pass locally while CI failed. |
| RELEASING: the build job packages three platform artifacts | It packages two macOS zips (`kyde-macos.zip`, `kyde-macos-x86_64.zip`) + `.sha256`, signed/notarized/stapled. Linux and Windows are commented out in `release.yml`. |
| RELEASING: "while Kyde is `0.x`…" | Kyde is 2.5.0. Section rewritten; also documents that release-please owns **two** version fields (`[package]` + `[workspace.package]` via `extra-files`), not one. |
| README: no caret-follow scrolling | It ships (`reveal_pending`). Soft-wrap is the real gap, and only in the file editor. |
| README: menu bar is Settings / FPS / Quit | Also Plugins, What's New, Clear Data & Restart, and a File menu with Open + Recent Projects. |
| README: **Push** when ahead of upstream | Pull and Fetch ship too. |
| README: file management = New File, Rename, Delete | 2.5.0 added cut/copy/paste, drag & drop, folder rename, the non-git guard. |
| SECURITY: `src/git.rs`, "pre-1.0" | Now `crates/kyde-git/src/lib.rs`; the version line is gone. |
| Landing page: `xattr -dr com.apple.quarantine` | The release is Developer ID signed, notarized and stapled — the quarantine dance is unnecessary and reads as unsigned. |

### Shipped but undocumented, now covered

Worktree switcher (its screenshot was already committed but unused), compare two files, ⌘-click navigation, error squiggles, Sort Lines / Sort Object Keys, back/forward navigation, What's New, the in-app updater, single-instance launches, and the light + colour-vision-deficiency palettes. Missing shortcuts added to the keymap list (`⌘⇧F`, `⌘⌥←/→`, `⌥⌘L`/`⌥⌘S`, ``⌃` ``).

SECURITY's threat model also gained the in-app updater and the single-instance socket.

## Testing

Docs only, no code changed, so nothing to run beyond reading the rendered diff.

## Note

`SECURITY.md` still lists `kyle.johnson@flagsmith.com` as the contact — left alone deliberately. Change it if that's stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)