### PR TITLE
Fix/windows terminal shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 See [RELEASING.md](RELEASING.md) for how releases are cut.
 
+## Unreleased
+
+### Bug Fixes
+
+* use the system command shell when opening the embedded terminal on Windows
+
 ## [2.5.0](https://github.com/kyle-ssg/kyde/compare/kyde-v2.4.0...kyde-v2.5.0) (2026-07-27)
 
 All shipped together in [#69](https://github.com/kyle-ssg/kyde/pull/69) ([588e364](https://github.com/kyle-ssg/kyde/commit/588e364481bb7daf730e664583d26991122382a9)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Bug Fixes
 
+* keep Windows builds compiling when Unix-only single-instance IPC is unavailable
 * use the system command shell when opening the embedded terminal on Windows
 
 ## [2.5.0](https://github.com/kyle-ssg/kyde/compare/kyde-v2.4.0...kyde-v2.5.0) (2026-07-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Bug Fixes
 
+* relay Enter to the embedded terminal instead of consuming it as an app confirmation shortcut
 * keep Windows builds compiling when Unix-only single-instance IPC is unavailable
 * use the system command shell when opening the embedded terminal on Windows
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,6 +3065,7 @@ name = "kyde-update"
 version = "2.5.0"
 dependencies = [
  "serde_json",
+ "sha2",
  "thiserror 2.0.19",
 ]
 

--- a/crates/kyde-git/src/lib.rs
+++ b/crates/kyde-git/src/lib.rs
@@ -378,11 +378,7 @@ impl Repo {
     /// The entry's mode follows the working file's executable bit.
     pub fn stage_content(&self, rel: &Path, content: &str) -> Result<()> {
         let oid = git_stdin(&self.root, &["hash-object", "-w", "--stdin"], content)?;
-        let mode = if is_executable(&self.root.join(rel)) {
-            "100755"
-        } else {
-            "100644"
-        };
+        let mode = stage_content_mode(&self.root, rel)?;
         let info = format!("{mode},{},{}", oid.trim(), rel.to_string_lossy());
         git(&self.root, &["update-index", "--add", "--cacheinfo", &info]).map(|_| ())
     }
@@ -1065,17 +1061,21 @@ fn git(dir: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
-/// Whether the on-disk file has any executable bit set (false when absent).
+/// Select the index mode for partially staged content from the working file's executable bit.
 #[cfg(unix)]
-fn is_executable(path: &Path) -> bool {
+fn stage_content_mode(root: &Path, rel: &Path) -> Result<&'static str> {
     use std::os::unix::fs::PermissionsExt;
-    std::fs::metadata(path).is_ok_and(|m| m.permissions().mode() & 0o111 != 0)
+    let executable = std::fs::metadata(root.join(rel))
+        .is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0);
+    Ok(if executable { "100755" } else { "100644" })
 }
 
-/// Whether the on-disk file has any executable bit set (always false off-unix).
+/// Windows has no Unix executable permission, so preserve the mode already stored by Git.
 #[cfg(not(unix))]
-fn is_executable(_path: &Path) -> bool {
-    false
+fn stage_content_mode(root: &Path, rel: &Path) -> Result<&'static str> {
+    let entry = git(root, &["ls-files", "--stage", "--", &rel.to_string_lossy()])?;
+    let executable = entry.lines().any(|line| line.starts_with("100755 "));
+    Ok(if executable { "100755" } else { "100644" })
 }
 
 fn git_stdin(dir: &Path, args: &[&str], stdin: &str) -> Result<String> {
@@ -1320,6 +1320,7 @@ mod tests {
         g(&work, &["config", "user.email", "t@example.com"]);
         g(&work, &["config", "user.name", "Test"]);
         g(&work, &["config", "commit.gpgsign", "false"]);
+        g(&work, &["config", "core.autocrlf", "false"]);
         fs::write(work.join("f.txt"), "one\ntwo\nthree\n").unwrap();
         g(&work, &["add", "-A"]);
         g(&work, &["commit", "-m", "init"]);
@@ -1420,6 +1421,7 @@ mod tests {
         g(&work, &["config", "user.email", "t@example.com"]);
         g(&work, &["config", "user.name", "Test"]);
         g(&work, &["config", "commit.gpgsign", "false"]);
+        g(&work, &["config", "core.autocrlf", "false"]);
         fs::write(work.join("f.txt"), "one\ntwo\nthree\n").unwrap();
         fs::write(work.join("other.txt"), "x\n").unwrap();
         g(&work, &["add", "-A"]);

--- a/crates/kyde-tree/src/lib.rs
+++ b/crates/kyde-tree/src/lib.rs
@@ -121,18 +121,15 @@ mod tests {
         exp.insert(p("src"));
         exp.insert(p("empty"));
         let rows = t.visible(&exp);
-        let names: Vec<_> = rows
-            .iter()
-            .map(|r| (r.path.to_string_lossy().into_owned(), r.is_dir))
-            .collect();
+        let entries: Vec<_> = rows.iter().map(|r| (r.path.clone(), r.is_dir)).collect();
         assert_eq!(
-            names,
+            entries,
             vec![
-                ("empty".to_string(), true),
-                ("empty/nested".to_string(), true),
-                ("src".to_string(), true),
-                ("src/new".to_string(), true),
-                ("src/main.rs".to_string(), false),
+                (p("empty"), true),
+                (p("empty/nested"), true),
+                (p("src"), true),
+                (p("src/new"), true),
+                (p("src/main.rs"), false),
             ]
         );
     }

--- a/crates/kyde-tree/src/lib.rs
+++ b/crates/kyde-tree/src/lib.rs
@@ -149,23 +149,23 @@ mod tests {
         let mut exp = HashSet::new();
         // Collapsed: only top-level entries, folders first.
         let rows = t.visible(&exp);
-        let names: Vec<_> = rows
-            .iter()
-            .map(|r| r.path.to_string_lossy().into_owned())
-            .collect();
-        assert_eq!(names, vec!["a", "src", "README.md"]);
+        let paths: Vec<_> = rows.iter().map(|r| r.path.clone()).collect();
+        assert_eq!(paths, vec![p("a"), p("src"), p("README.md")]);
         assert!(rows[0].is_dir && rows[1].is_dir && !rows[2].is_dir);
 
         // Expand src → its files appear under it at depth 1.
         exp.insert(p("src"));
         let rows = t.visible(&exp);
-        let names: Vec<_> = rows
-            .iter()
-            .map(|r| r.path.to_string_lossy().into_owned())
-            .collect();
+        let paths: Vec<_> = rows.iter().map(|r| r.path.clone()).collect();
         assert_eq!(
-            names,
-            vec!["a", "src", "src/git.rs", "src/main.rs", "README.md"]
+            paths,
+            vec![
+                p("a"),
+                p("src"),
+                p("src").join("git.rs"),
+                p("src").join("main.rs"),
+                p("README.md")
+            ]
         );
         assert_eq!(rows[2].depth, 1);
     }

--- a/crates/kyde-update/Cargo.toml
+++ b/crates/kyde-update/Cargo.toml
@@ -11,6 +11,7 @@ description = "GitHub release check + self-update for Kyde. Pure, no GUI."
 # Typed errors for a library crate (rule: libs use thiserror, never anyhow).
 thiserror.workspace = true
 serde_json.workspace = true
+sha2 = "0.10"
 
 [lints]
 workspace = true

--- a/crates/kyde-update/src/lib.rs
+++ b/crates/kyde-update/src/lib.rs
@@ -12,6 +12,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use sha2::{Digest, Sha256};
+
 /// Everything self-update can fail with. Each variant carries context — which external command
 /// failed and its stderr, or the I/O operation + underlying error. (Library crate → typed
 /// errors via `thiserror`, never `anyhow`.)
@@ -336,9 +338,7 @@ fn curl_security_args(url: &str) -> &'static [&'static str] {
 }
 
 /// Verify `file`'s SHA-256 against the checksum published at `sha256_url` (a text file whose
-/// first whitespace-separated token is the hex digest — `shasum -a 256` output). The local
-/// digest is computed by shelling to `shasum` (ships with macOS), matching this crate's
-/// no-extra-deps philosophy.
+/// first whitespace-separated token is the hex digest — `shasum -a 256` output).
 fn verify_checksum(file: &Path, sha256_url: &str) -> Result<()> {
     let body = curl_text(sha256_url)?;
     let expected = body
@@ -352,27 +352,29 @@ fn verify_checksum(file: &Path, sha256_url: &str) -> Result<()> {
             actual: String::new(),
         });
     }
-    let out = Command::new("shasum")
-        .args(["-a", "256"])
-        .arg(file)
-        .output()
-        .map_err(io_err("spawning shasum"))?;
-    if !out.status.success() {
-        return Err(UpdateError::Command {
-            action: "checksum".into(),
-            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
-        });
-    }
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let actual = stdout
-        .split_whitespace()
-        .next()
-        .unwrap_or("")
-        .to_ascii_lowercase();
+    let actual = sha256_file(file)?;
     if actual != expected {
         return Err(UpdateError::ChecksumMismatch { expected, actual });
     }
     Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path).map_err(io_err(format!("opening {path:?}")))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(io_err(format!("reading {path:?}")))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 /// Download `zip_url`, verify it against `sha256_url`, unzip, and swap the new `Kyde.app`
@@ -609,18 +611,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let payload = dir.join("payload.bin");
         std::fs::write(&payload, b"hello update\n").unwrap();
-        // Compute the real digest the same way the verifier does (shasum ships on macOS
-        // and the Linux CI runners alike).
-        let out = Command::new("shasum")
-            .args(["-a", "256"])
-            .arg(&payload)
-            .output()
-            .expect("shasum available");
-        let digest = String::from_utf8_lossy(&out.stdout)
-            .split_whitespace()
-            .next()
-            .unwrap()
-            .to_string();
+        let digest = "85ebff07175145475a29610a59842c3f0e9b74d72ce23b3c535bd01eeca62027";
         let good = dir.join("payload.bin.sha256");
         std::fs::write(&good, format!("{digest}  payload.bin\n")).unwrap();
         let good_url = format!("file://{}", good.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,7 @@ actions!(
         NewTerminalTab,
         CloseTerminalTab,
         ClearTerminal,
+        TerminalEnter,
         TerminalBackspace,
         TerminalEscape,
         DeleteFile,
@@ -290,12 +291,13 @@ fn apply_keymap(cx: &mut App, km: &Keymap) {
         KeyBinding::new("cmd-w", CloseTerminalTab, Some("Terminal")),
         // ⌘K clears the terminal; "Terminal" context (depth) beats the "Kyde"-scoped commit.
         KeyBinding::new("cmd-k", ClearTerminal, Some("Terminal")),
-        // Bare backspace / escape are app shortcuts in "Kyde" (DeleteFile / EscapeKey). gpui
+        // Enter / backspace / escape are app shortcuts in "Kyde". gpui
         // dispatches binding ACTIONS *before* on_key_down and an action stops propagation by
         // default, so on_key_down never runs once a binding matches — meaning a no-op here would
         // swallow the key (nothing reaches the PTY). So these route to actions whose handlers
         // (on TerminalView) write the raw byte to the shell, exactly like the editor binds
         // backspace to its own buffer action. The "Terminal" context (depth) shadows "Kyde".
+        KeyBinding::new("enter", TerminalEnter, Some("Terminal")),
         KeyBinding::new("backspace", TerminalBackspace, Some("Terminal")),
         // ⌘⌫ is DeleteFile in "Kyde" (issue #61); in the terminal it must act as a plain
         // backspace, not delete the tree-selected file out from under a typing user.
@@ -5242,6 +5244,49 @@ mod gpui_smoke_tests {
                 assert!(!k.term.panel.open, "closing the last tab hides the panel");
             })
             .unwrap();
+    }
+
+    /// Enter is also bound at the app root (`ConfirmKey`). The deeper Terminal binding must win
+    /// and relay CR to the PTY instead of letting the root action consume the key.
+    #[cfg(feature = "terminal")]
+    #[gpui::test]
+    fn terminal_enter_binding_sends_carriage_return(cx: &mut TestAppContext) {
+        cx.update(|cx| apply_keymap(cx, &Keymap::default()));
+        let routed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let _observer = cx.update(|cx| {
+            let routed = routed.clone();
+            cx.observe_keystrokes(move |event, _window, _cx| {
+                if event
+                    .action
+                    .as_ref()
+                    .is_some_and(|action| action.partial_eq(&TerminalEnter))
+                {
+                    routed.store(true, std::sync::atomic::Ordering::Relaxed);
+                }
+            })
+        });
+        let (handle, _dir) = boot(cx);
+        handle
+            .update(cx, |k, window, cx| {
+                k.act_toggle_terminal(&ToggleTerminal, window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, window, cx| k.focus_active_terminal(window, cx))
+            .unwrap();
+        cx.run_until_parked();
+        handle
+            .update(cx, |k, window, cx| {
+                let enter = gpui::Keystroke::parse("enter").expect("valid Enter keystroke");
+                window.dispatch_keystroke(enter, cx);
+                assert!(k.term.panel.open);
+            })
+            .unwrap();
+        assert!(
+            routed.load(std::sync::atomic::Ordering::Relaxed),
+            "TerminalEnter must shadow the root ConfirmKey binding"
+        );
     }
 
     /// The shell exiting (`^D` / `exit`) makes the IO thread emit `CloseRequested`; the Kyde

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,9 @@ use widgets::terminal;
 
 // ── small OS utilities ──
 mod platform;
-use platform::{clipboard as os_clipboard, instance, scratch, shellcmd};
+#[cfg(unix)]
+use platform::instance;
+use platform::{clipboard as os_clipboard, scratch, shellcmd};
 
 // ── workspace crates, aliased back to their old module names ──
 use kyde_config::keymap;
@@ -2912,7 +2914,9 @@ fn main() {
     // `kyde <path>` hands the path to the running Kyde (which opens it as another tab and
     // comes forward) and exits here, before any window is created. Nothing listening → we
     // are the instance, and take the socket over below.
+    #[cfg(unix)]
     let guarded = instance::enabled();
+    #[cfg(unix)]
     if guarded {
         let req = initial
             .clone()
@@ -3010,6 +3014,7 @@ fn main() {
         // touch gpui entities, so it only forwards over a channel to this foreground pump —
         // the terminal `EventProxy` / fs-watcher pattern. The guard lives in the task, so the
         // socket is unlinked when the app goes away.
+        #[cfg(unix)]
         if guarded {
             let (tx, mut rx) = futures::channel::mpsc::unbounded::<instance::Request>();
             if let Some((guard, _thread)) = instance::listen(move |req| {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,5 +1,6 @@
 //! Small OS-integration utilities (no gpui): shell-command install, scratch paths.
 pub(crate) mod clipboard;
+#[cfg(unix)]
 pub(crate) mod instance;
 pub(crate) mod scratch;
 pub(crate) mod shellcmd;

--- a/src/platform/shellcmd.rs
+++ b/src/platform/shellcmd.rs
@@ -150,6 +150,7 @@ mod tests {
         (exe, bin)
     }
 
+    #[cfg(unix)]
     #[test]
     fn available_then_installed_roundtrip() {
         let (exe, bin) = setup();
@@ -177,6 +178,7 @@ mod tests {
         assert_eq!(state_in(&exe, &[bin]), State::NameTaken);
     }
 
+    #[cfg(unix)]
     #[test]
     fn our_symlink_elsewhere_on_path_counts_as_installed() {
         let (exe, bin) = setup();

--- a/src/widgets/terminal.rs
+++ b/src/widgets/terminal.rs
@@ -240,7 +240,7 @@ impl TerminalView {
         self.write(text.as_bytes().to_vec());
     }
 
-    /// Relay a key's raw bytes to the PTY from an action handler (backspace / escape): jump to
+    /// Relay a key's raw bytes to the PTY from an action handler (Enter / backspace / escape): jump to
     /// the live screen, write, repaint — the same steps `on_key` does for typed keys.
     fn send_key(&mut self, bytes: Vec<u8>, cx: &mut Context<Self>) {
         self.term.lock().scroll_display(Scroll::Bottom);
@@ -501,10 +501,13 @@ impl Render for TerminalView {
             // ⌘K clears the current (unsubmitted) input line — overrides the global commit
             // binding in this context.
             .on_action(cx.listener(|this, _: &crate::ClearTerminal, _w, cx| this.clear_input(cx)))
-            // Backspace / Escape are also app shortcuts (DeleteFile / EscapeKey). gpui dispatches
+            // Enter / Backspace / Escape are also app shortcuts. gpui dispatches
             // binding actions before on_key_down and consumes the key, so we relay the PTY byte
             // here rather than let it fall through to the app action (which deleted the selected
             // file / closed a modal). Mirrors how the editor binds backspace to a buffer action.
+            .on_action(cx.listener(|this, _: &crate::TerminalEnter, _w, cx| {
+                this.send_key(b"\r".to_vec(), cx);
+            }))
             .on_action(cx.listener(|this, _: &crate::TerminalBackspace, _w, cx| {
                 this.send_key(vec![0x7f], cx);
             }))

--- a/src/widgets/terminal.rs
+++ b/src/widgets/terminal.rs
@@ -42,6 +42,23 @@ use std::sync::Arc;
 const INIT_COLS: u16 = 80;
 const INIT_ROWS: u16 = 24;
 
+#[cfg(target_os = "windows")]
+fn default_shell() -> String {
+    windows_shell_from_comspec(std::env::var("COMSPEC").ok())
+}
+
+#[cfg(target_os = "windows")]
+fn windows_shell_from_comspec(comspec: Option<String>) -> String {
+    comspec
+        .filter(|shell| !shell.trim().is_empty())
+        .unwrap_or_else(|| "cmd.exe".to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn default_shell() -> String {
+    std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
+}
+
 /// Forwards alacritty IO-thread events to the gpui foreground over an unbounded channel.
 /// `Clone` because both the `Term` and the `EventLoop` need a handle to the same sink.
 #[derive(Clone)]
@@ -85,7 +102,7 @@ impl TerminalView {
         let (tx, mut rx) = unbounded::<AlacEvent>();
         let proxy = EventProxy(tx);
 
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        let shell = default_shell();
         let options = PtyOptions {
             shell: Some(Shell::new(shell, Vec::new())),
             working_directory: working_dir,
@@ -1065,6 +1082,20 @@ const ANSI_PALETTE: [Rgb; 16] = [
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_shell_uses_comspec_with_cmd_fallback() {
+        assert_eq!(
+            windows_shell_from_comspec(Some(r"C:\Windows\System32\cmd.exe".to_string())),
+            r"C:\Windows\System32\cmd.exe"
+        );
+        assert_eq!(windows_shell_from_comspec(None), "cmd.exe");
+        assert_eq!(
+            windows_shell_from_comspec(Some("  ".to_string())),
+            "cmd.exe"
+        );
+    }
 
     #[test]
     fn indexed_palette_covers_all_256_without_panicking() {


### PR DESCRIPTION
## What & why

Kyde currently reaches several Unix-only assumptions when built and used on Windows:

- The embedded terminal reads `$SHELL` and falls back to `/bin/zsh`, which cannot spawn on Windows.
- The app-level `ConfirmKey` binding consumes Enter before the focused terminal can submit a command.
- The single-instance implementation uses Unix-domain sockets.
- Update verification and tests assume `shasum`, Unix executable bits, LF line endings, or `/` path separators.

This PR makes those paths portable:

- Use `%COMSPEC%` for Windows terminal sessions, with `cmd.exe` as a fallback.
- Add a terminal-scoped Enter action that writes `\r` to the PTY, plus a GPUI dispatch regression test.
- Preserve executable modes from Git's index on Windows and make line-ending/path assertions platform-independent.
- Compute update SHA-256 checksums in-process. `sha2` is already in Kyde's normal dependency graph.
- Compile the Unix-socket single-instance guard only on Unix; Windows keeps the previous multi-instance behavior until it has native IPC.

## How to test

On Windows:

1. Put the Windows SDK directory containing `fxc.exe` on `PATH`.
2. Run `cargo build`.
3. Run `cargo test --all`.
4. Open a repository, toggle the terminal, enter `echo hello`, and press Enter.
5. Partially stage an executable file and confirm its index mode is preserved.

Checks completed on Windows:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `cargo build`

## Speed & footprint

- [x] No new work added to a **hot path** (per-keystroke highlight, per-frame render, per-file-select diff) - or if there is, it's justified and has a `perf_*` guard test.
- [x] No new **always-on dependency** that bloats the binary / resident RAM. `sha2` was already present in Kyde's normal dependency graph.
- [x] Startup still feels instant (the app should open before you finish letting go of the mouse).
- [ ] N/A - docs / chore / pure refactor with no runtime impact.

## Checklist

- [x] `cargo build` is clean (no new warnings).
- [x] `cargo test` is green (`cargo test perf` if you touched a hot path).
- [x] No vendor code or assets copied from Zed or any GPL source (patterns only - see README -> Reference material).
- [x] `CHANGELOG.md` is updated; `README.md` / `CLAUDE.md` do not need changes for this behavior.
